### PR TITLE
cleanup: remove white space on lines which were only space

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $client = new Client($accountAPIkey, $userAPIkey);
 ```
 
 The following is a list of public methods in Client.php that interact with the SmarterU API:
-    
+
 1. [createUser](docs/Client.md#clientcreateuser)
 2. [readUserById](docs/Client.md#clientreaduserbyid)
 3. [readUserByEmail](docs/Client.md#clientreaduserbyemail)
@@ -145,7 +145,7 @@ given to a Group. When adding or removing a LearningModule from a Group via the
 to a Group via the `createGroup` method, "action" is not used, while all other
 attributes are required. More information can be found in
 [docs/DataTypes/LearningModule.md](docs/DataTypes/LearningModule.md).
- 
+
 A SubscriptionVariant is a record of a subscription that is assigned to a Group.
 When adding or removing a SubscriptionVariant from a Group via the `updateGroup`
 method, all attributes are required. When adding a SubscriptionVariant to a

--- a/src/Client.php
+++ b/src/Client.php
@@ -248,9 +248,9 @@ class Client {
             ->getHttpClient()
             ->request(
                 'POST',
-                self::POST_URL, 
+                self::POST_URL,
                 ['form_params' => ['Package' => $xml]]
-        );
+            );
 
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
@@ -281,7 +281,7 @@ class Client {
     public function readUserById(string $id): ?User {
         $query = (new GetUserQuery())
             ->setId($id);
-        
+
         return $this->getUser($query);
     }
 
@@ -300,7 +300,7 @@ class Client {
     public function readUserByEmail(string $email): ?User {
         $query = (new GetUserQuery())
             ->setEmail($email);
-        
+
         return $this->getUser($query);
     }
 
@@ -319,7 +319,7 @@ class Client {
     public function readUserByEmployeeId(string $employeeId): ?User {
         $query = (new GetUserQuery())
             ->setEmployeeId($employeeId);
-        
+
         return $this->getUser($query);
     }
 
@@ -346,9 +346,9 @@ class Client {
             ->getHttpClient()
             ->request(
                 'POST',
-                self::POST_URL, 
+                self::POST_URL,
                 ['form_params' => ['Package' => $xml]]
-        );
+            );
 
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
@@ -431,9 +431,9 @@ class Client {
             ->getHttpClient()
             ->request(
                 'POST',
-                self::POST_URL, 
+                self::POST_URL,
                 ['form_params' => ['Package' => $xml]]
-        );
+            );
 
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
@@ -530,9 +530,9 @@ class Client {
             ->getHttpClient()
             ->request(
                 'POST',
-                self::POST_URL, 
+                self::POST_URL,
                 ['form_params' => ['Package' => $xml]]
-        );
+            );
 
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
@@ -610,9 +610,9 @@ class Client {
             ->getHttpClient()
             ->request(
                 'POST',
-                self::POST_URL, 
+                self::POST_URL,
                 ['form_params' => ['Package' => $xml]]
-        );
+            );
 
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
@@ -672,9 +672,9 @@ class Client {
             ->getHttpClient()
             ->request(
                 'POST',
-                self::POST_URL, 
+                self::POST_URL,
                 ['form_params' => ['Package' => $xml]]
-        );
+            );
 
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
@@ -684,7 +684,7 @@ class Client {
 
         $groupName = (string) $bodyAsXml->Info->Group;
         $groupId = (string) $bodyAsXml->Info->GroupID;
-    
+
         return (new Group())
             ->setName($groupName)
             ->setGroupId($groupId);
@@ -725,9 +725,9 @@ class Client {
             ->getHttpClient()
             ->request(
                 'POST',
-                self::POST_URL, 
+                self::POST_URL,
                 ['form_params' => ['Package' => $xml]]
-        );
+            );
 
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
@@ -774,9 +774,9 @@ class Client {
             ->getHttpClient()
             ->request(
                 'POST',
-                self::POST_URL, 
+                self::POST_URL,
                 ['form_params' => ['Package' => $xml]]
-        );
+            );
 
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
@@ -844,9 +844,9 @@ class Client {
             ->getHttpClient()
             ->request(
                 'POST',
-                self::POST_URL, 
+                self::POST_URL,
                 ['form_params' => ['Package' => $xml]]
-        );
+            );
 
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
@@ -914,9 +914,9 @@ class Client {
             ->getHttpClient()
             ->request(
                 'POST',
-                self::POST_URL, 
+                self::POST_URL,
                 ['form_params' => ['Package' => $xml]]
-        );
+            );
 
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
@@ -958,9 +958,9 @@ class Client {
             ->getHttpClient()
             ->request(
                 'POST',
-                self::POST_URL, 
+                self::POST_URL,
                 ['form_params' => ['Package' => $xml]]
-        );
+            );
 
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
@@ -1080,7 +1080,7 @@ class Client {
             $learnerReports[] = $currentReport;
         }
 
-        return $learnerReports;        
+        return $learnerReports;
     }
 
     /**
@@ -1390,7 +1390,7 @@ class Client {
                 'POST',
                 self::POST_URL,
                 ['form_params' => ['Package' => $xml]]
-        );
+            );
 
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 

--- a/src/DataTypes/Group.php
+++ b/src/DataTypes/Group.php
@@ -520,7 +520,7 @@ class Group {
         $this->userHelpOverrideDefault = $userHelpOverrideDefault;
         return $this;
     }
-    
+
     /**
      * Get whether a link displays in the header of the learner interface that
      * enables users who have the group as their home group to request help.

--- a/src/DataTypes/LearnerReport.php
+++ b/src/DataTypes/LearnerReport.php
@@ -85,7 +85,7 @@ class LearnerReport {
      * The ID of the Group containing this training assignment.
      */
     protected ?string $groupId = null;
-    
+
     /**
      * The name of the Group containing this training assignment.
      */

--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -1005,7 +1005,7 @@ class XMLGenerator {
         }
         $info = $userTag->addChild('Info');
         $profile = $userTag->addChild('Profile');
-        
+
         $groups = $userTag->addChild('Groups');
         $groupTag = $groups->addChild('Group');
         if (!empty($group->getName())) {
@@ -1095,7 +1095,8 @@ class XMLGenerator {
         }
         if ($this->includeLearningModulesTag($query)) {
             $learningModules = $filters->addChild('LearningModules');
-            if (!empty($query->getLearningModuleStatus())
+            if (
+                !empty($query->getLearningModuleStatus())
                 || !empty($query->getLearningModuleNames())
             ) {
                 $learningModule = $learningModules->addChild('LearningModule');

--- a/tests/Client/CreateGroupClientTest.php
+++ b/tests/Client/CreateGroupClientTest.php
@@ -120,7 +120,7 @@ class CreateGroupClientTest extends TestCase {
 
         $name = $this->group->getName();
         $groupId = $this->group->getGroupId();
-        
+
         $xmlString = <<<XML
         <SmarterU>
             <Result>Success</Result>
@@ -132,7 +132,7 @@ class CreateGroupClientTest extends TestCase {
             </Errors>
         </SmarterU>
         XML;
-    
+
         // Set up the container to capture the request.
         $response = new Response(200, [], $xmlString);
         $container = [];
@@ -142,10 +142,10 @@ class CreateGroupClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-    
+
         // Make the request.
         $client->createGroup($this->group);
-    
+
         // Make sure there is only 1 request, then translate it to XML.
         self::assertCount(1, $container);
         $request = $container[0]['request'];
@@ -190,7 +190,7 @@ class CreateGroupClientTest extends TestCase {
         $client = new Client($accountApi, $userApi);
 
         $groupId = $this->group->getGroupId();
-        
+
         $xmlString = <<<XML
         <SmarterU>
             <Result>Success</Result>
@@ -201,7 +201,7 @@ class CreateGroupClientTest extends TestCase {
             </Errors>
         </SmarterU>
         XML;
-    
+
         // Set up the container to capture the request.
         $response = new Response(200, [], $xmlString);
         $container = [];
@@ -211,10 +211,10 @@ class CreateGroupClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-    
+
         // Make the request.
         $client->createGroup($group);
-    
+
         // Make sure there is only 1 request, then translate it to XML.
         self::assertCount(1, $container);
         $request = $container[0]['request'];
@@ -242,11 +242,11 @@ class CreateGroupClientTest extends TestCase {
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -280,21 +280,21 @@ class CreateGroupClientTest extends TestCase {
             </Errors>
         </SmarterU>
         XML;
-    
+
         $xml = simplexml_load_string($xmlString);
         $body = $xml->asXML();
 
         $response = new Response(200, [], $body);
-    
+
         $container = [];
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -327,7 +327,7 @@ class CreateGroupClientTest extends TestCase {
             </Errors>
         </SmarterU>
         XML;
-    
+
         $response = new Response(200, [], $xmlString);
         $container = [];
         $history = Middleware::history($container);
@@ -336,10 +336,10 @@ class CreateGroupClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-            
+
         // Make the request.
         $result = $client->createGroup($this->group);
-        
+
         self::assertInstanceOf(Group::class, $result);
         self::assertEquals($this->group->getName(), $result->getName());
         self::assertEquals($this->group->getGroupId(), $result->getGroupId());

--- a/tests/Client/CreateUserClientTest.php
+++ b/tests/Client/CreateUserClientTest.php
@@ -117,7 +117,7 @@ class CreateUserClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-        
+
         // Make the request.
         $client->createUser($this->user1);
 
@@ -148,11 +148,11 @@ class CreateUserClientTest extends TestCase {
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -176,7 +176,7 @@ class CreateUserClientTest extends TestCase {
         <SmarterU>
         </SmarterU>
         XML;
-    
+
         $xml = simplexml_load_string($xmlString);
         $xml->addChild('Result', 'Failed');
         $xml->addChild('Info');
@@ -190,16 +190,16 @@ class CreateUserClientTest extends TestCase {
         $body = $xml->asXML();
 
         $response = new Response(200, [], $body);
-    
+
         $container = [];
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -231,7 +231,7 @@ class CreateUserClientTest extends TestCase {
         $info->addChild('EmployeeID', $this->user1->getEmployeeId());
         $xml->addChild('Errors');
         $body = $xml->asXML();
-    
+
         $response = new Response(200, [], $body);
         $container = [];
         $history = Middleware::history($container);
@@ -240,10 +240,10 @@ class CreateUserClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-            
+
         // Make the request.
         $result = $client->createUser($this->user1);
-        
+
         self::assertInstanceOf(User::class, $result);
         self::assertEquals($result->getEmail(), $this->user1->getEmail());
         self::assertEquals(

--- a/tests/Client/GetGroupClientTest.php
+++ b/tests/Client/GetGroupClientTest.php
@@ -244,11 +244,11 @@ class GetGroupClientTest extends TestCase {
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -283,21 +283,21 @@ class GetGroupClientTest extends TestCase {
             </Errors>
         </SmarterU>
         XML;
-    
+
         $xml = simplexml_load_string($xmlString);
         $body = $xml->asXML();
 
         $response = new Response(200, [], $body);
-    
+
         $container = [];
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -351,7 +351,7 @@ class GetGroupClientTest extends TestCase {
             </Errors>
         </SmarterU>
         XML;
-    
+
         $response = new Response(200, [], $xmlString);
         $container = [];
         $history = Middleware::history($container);
@@ -360,10 +360,10 @@ class GetGroupClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-            
+
         // Make the request.
         $result = $client->readGroupById($groupId);
-        
+
         self::assertNull($result);
     }
 
@@ -430,7 +430,7 @@ class GetGroupClientTest extends TestCase {
             </Errors>
         </SmarterU>
         XML;
-    
+
         $response = new Response(200, [], $xmlString);
         $container = [];
         $history = Middleware::history($container);
@@ -439,10 +439,10 @@ class GetGroupClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-            
+
         // Make the request.
         $result = $client->readGroupById($groupId);
-        
+
         self::assertInstanceOf(Group::class, $result);
         self::assertEquals($name, $result->getName());
         self::assertEquals(new DateTime($createdDate), $result->getCreatedDate());

--- a/tests/Client/GetUserClientTest.php
+++ b/tests/Client/GetUserClientTest.php
@@ -450,11 +450,11 @@ class GetUserClientTest extends TestCase {
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -477,7 +477,7 @@ class GetUserClientTest extends TestCase {
         <SmarterU>
         </SmarterU>
         XML;
-    
+
         $xml = simplexml_load_string($xmlString);
         $xml->addChild('Result', 'Failed');
         $xml->addChild('Info');
@@ -491,16 +491,16 @@ class GetUserClientTest extends TestCase {
         $body = $xml->asXML();
 
         $response = new Response(200, [], $body);
-    
+
         $container = [];
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -534,7 +534,7 @@ class GetUserClientTest extends TestCase {
         $error->addChild('ErrorID', 'GU:03');
         $error->addChild('ErrorMessage', 'The user requested does not exist.');
         $body = $xml->asXML();
-    
+
         $response = new Response(200, [], $body);
         $container = [];
         $history = Middleware::history($container);
@@ -543,10 +543,10 @@ class GetUserClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-            
+
         // Make the request.
         $result = $client->readUserByEmployeeId($this->user1->getEmployeeId());
-        
+
         self::assertNull($result);
     }
 
@@ -558,7 +558,7 @@ class GetUserClientTest extends TestCase {
         $accountApi = 'account';
         $userApi = 'user';
         $client = new Client($accountApi, $userApi);
-        
+
         $createdDate = '2022-07-29';
         $modifiedDate = '2022-07-30';
 
@@ -628,7 +628,7 @@ class GetUserClientTest extends TestCase {
         );
         $errors = $xml->addChild('Errors');
         $body = $xml->asXML();
-    
+
         $response = new Response(200, [], $body);
         $container = [];
         $history = Middleware::history($container);
@@ -637,10 +637,10 @@ class GetUserClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-            
+
         // Make the request.
         $result = $client->readUserById($this->user1->getId());
-        
+
         self::assertInstanceOf(User::class, $result);
         self::assertEquals($this->user1->getId(), $result->getId());
         self::assertEquals(

--- a/tests/Client/GetUserGroupsClientTest.php
+++ b/tests/Client/GetUserGroupsClientTest.php
@@ -252,11 +252,11 @@ class GetUserGroupsClientTest extends TestCase {
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -290,21 +290,21 @@ class GetUserGroupsClientTest extends TestCase {
             </Errors>
         </SmarterU>
         XML;
-    
+
         $xml = simplexml_load_string($xmlString);
         $body = $xml->asXML();
 
         $response = new Response(200, [], $body);
-    
+
         $container = [];
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -324,7 +324,7 @@ class GetUserGroupsClientTest extends TestCase {
         $accountApi = 'account';
         $userApi = 'user';
         $client = new Client($accountApi, $userApi);
-        
+
         $name1 = 'My Group';
         $identifier1 = '1';
         $isHomeGroup1 = '0';
@@ -351,7 +351,7 @@ class GetUserGroupsClientTest extends TestCase {
             </Errors>
         </SmarterU>
         XML;
-    
+
         $response = new Response(200, [], $xmlString);
         $container = [];
         $history = Middleware::history($container);
@@ -360,10 +360,10 @@ class GetUserGroupsClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-            
+
         // Make the request.
         $result = $client->readGroupsForUserByEmployeeId('5');
-        
+
         self::assertIsArray($result);
         self::assertCount(1, $result);
         self::assertInstanceOf(Group::class, $result[0]);
@@ -388,7 +388,7 @@ class GetUserGroupsClientTest extends TestCase {
         $accountApi = 'account';
         $userApi = 'user';
         $client = new Client($accountApi, $userApi);
-        
+
         $name1 = 'My Group';
         $identifier1 = '1';
         $isHomeGroup1 = '0';
@@ -400,7 +400,7 @@ class GetUserGroupsClientTest extends TestCase {
         $name3 = 'Third Group';
         $identifier3 = '3';
         $isHomeGroup3 = '0';
-        
+
         $createdDate = '2022-07-29';
         $modifiedDate = '2022-07-30';
 
@@ -439,7 +439,7 @@ class GetUserGroupsClientTest extends TestCase {
             </Errors>
         </SmarterU>
         XML;
-    
+
         $response = new Response(200, [], $xmlString);
         $container = [];
         $history = Middleware::history($container);
@@ -448,7 +448,7 @@ class GetUserGroupsClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-            
+
         // Make the request.
         $result = $client->readGroupsForUserById('1');
 

--- a/tests/Client/ListGroupsClientTest.php
+++ b/tests/Client/ListGroupsClientTest.php
@@ -129,7 +129,7 @@ class ListGroupsClientTest extends TestCase {
             ->setTagName('My Tag')
             ->setTagValues('Tag 2 values');
         $tags = [$tag1, $tag2];
-        
+
         $query = (new ListGroupsQuery())
             ->setAccountApi($accountApi)
             ->setUserApi($userApi)
@@ -217,11 +217,11 @@ class ListGroupsClientTest extends TestCase {
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -257,21 +257,21 @@ class ListGroupsClientTest extends TestCase {
             </Errors>
         </SmarterU>
         XML;
-    
+
         $xml = simplexml_load_string($xmlString);
         $body = $xml->asXML();
 
         $response = new Response(200, [], $body);
-    
+
         $container = [];
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);

--- a/tests/Client/ListUsersClientTest.php
+++ b/tests/Client/ListUsersClientTest.php
@@ -305,11 +305,11 @@ class ListUsersClientTest extends TestCase {
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -335,7 +335,7 @@ class ListUsersClientTest extends TestCase {
         <SmarterU>
         </SmarterU>
         XML;
-    
+
         $xml = simplexml_load_string($xmlString);
         $xml->addChild('Result', 'Failed');
         $xml->addChild('Info');
@@ -349,16 +349,16 @@ class ListUsersClientTest extends TestCase {
         $body = $xml->asXML();
 
         $response = new Response(200, [], $body);
-    
+
         $container = [];
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -433,7 +433,7 @@ class ListUsersClientTest extends TestCase {
         $info->addChild('TotalRecords', '0');
         $errors = $xml->addChild('Errors');
         $body = $xml->asXML();
-    
+
         $response = new Response(200, [], $body);
         $container = [];
         $history = Middleware::history($container);
@@ -442,10 +442,10 @@ class ListUsersClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-            
+
         // Make the request.
         $result = $client->listUsers($query);
-        
+
         self::assertIsArray($result);
         self::assertCount(0, $result);
     }
@@ -536,7 +536,7 @@ class ListUsersClientTest extends TestCase {
         $info->addChild('TotalRecords', '1');
         $errors = $xml->addChild('Errors');
         $body = $xml->asXML();
-    
+
         $response = new Response(200, [], $body);
         $container = [];
         $history = Middleware::history($container);
@@ -545,10 +545,10 @@ class ListUsersClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-            
+
         // Make the request.
         $result = $client->listUsers($query);
-        
+
         self::assertIsArray($result);
         self::assertCount(1, $result);
         self::assertInstanceOf(User::class, $result[0]);
@@ -740,7 +740,7 @@ class ListUsersClientTest extends TestCase {
         $info->addChild('TotalRecords', '3');
         $errors = $xml->addChild('Errors');
         $body = $xml->asXML();
-    
+
         $response = new Response(200, [], $body);
         $container = [];
         $history = Middleware::history($container);
@@ -749,10 +749,10 @@ class ListUsersClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-            
+
         // Make the request.
         $result = $client->listUsers($query);
-        
+
         self::assertIsArray($result);
         self::assertCount(3, $result);
         self::assertInstanceOf(User::class, $result[0]);

--- a/tests/Client/UpdateUserClientTest.php
+++ b/tests/Client/UpdateUserClientTest.php
@@ -151,7 +151,7 @@ class UpdateUserClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-        
+
         // Make the request.
         $client->updateUser($user);
 
@@ -214,7 +214,7 @@ class UpdateUserClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-        
+
         // Make the request.
         $client->updateUser($user);
 
@@ -253,11 +253,11 @@ class UpdateUserClientTest extends TestCase {
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -281,7 +281,7 @@ class UpdateUserClientTest extends TestCase {
         <SmarterU>
         </SmarterU>
         XML;
-    
+
         $xml = simplexml_load_string($xmlString);
         $xml->addChild('Result', 'Failed');
         $xml->addChild('Info');
@@ -295,16 +295,16 @@ class UpdateUserClientTest extends TestCase {
         $body = $xml->asXML();
 
         $response = new Response(200, [], $body);
-    
+
         $container = [];
         $history = Middleware::history($container);
 
         $mock = (new MockHandler([$response]));
-            
+
         $handlerStack = HandlerStack::create($mock);
 
         $handlerStack->push($history);
-            
+
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $client->setHttpClient($httpClient);
@@ -336,7 +336,7 @@ class UpdateUserClientTest extends TestCase {
         $info->addChild('EmployeeID', $this->user1->getEmployeeId());
         $xml->addChild('Errors');
         $body = $xml->asXML();
-    
+
         $response = new Response(200, [], $body);
         $container = [];
         $history = Middleware::history($container);
@@ -345,10 +345,10 @@ class UpdateUserClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $client->setHttpClient($httpClient);
-            
+
         // Make the request.
         $result = $client->updateUser($this->user1);
-        
+
         self::assertInstanceOf(User::class, $result);
         self::assertEquals($result->getEmail(), $this->user1->getEmail());
         self::assertEquals(

--- a/tests/Queries/GetLearnerReportQueryTest.php
+++ b/tests/Queries/GetLearnerReportQueryTest.php
@@ -182,7 +182,7 @@ class GetLearnerReportQueryTest extends TestCase {
         );
         $query->setGroupStatus('Invalid');
     }
-    
+
     /**
      * Test that GetLearnerReportQuery::setGroupNames() throws an exception
      * when the provided name is not a string.

--- a/tests/Queries/ListGroupsQueryTest.php
+++ b/tests/Queries/ListGroupsQueryTest.php
@@ -41,7 +41,7 @@ class ListGroupsQueryTest extends TestCase {
             ->setTagName('My Tag')
             ->setTagValues('Tag 2 values');
         $tags = [$tag1, $tag2];
-        
+
         $query = (new ListGroupsQuery())
             ->setAccountApi($accountApi)
             ->setUserApi($userApi)

--- a/tests/Queries/ListUsersQueryTest.php
+++ b/tests/Queries/ListUsersQueryTest.php
@@ -77,7 +77,7 @@ class ListUsersQueryTest extends TestCase {
             ->setCreatedDate($createdDate)
             ->setModifiedDate($modifiedDate)
             ->setTeams($teams);
-        
+
         self::assertEquals($accountApi, $query->getAccountApi());
         self::assertEquals($userApi, $query->getUserApi());
         self::assertEquals($page, $query->getPage());

--- a/tests/XMLGenerator/ChangePermissionsXMLTest.php
+++ b/tests/XMLGenerator/ChangePermissionsXMLTest.php
@@ -75,7 +75,7 @@ class ChangePermissionsXMLTest extends TestCase {
             'Add'
         );
     }
-    
+
     /**
      * Test that XMLGenerator::changePermissions() produces the correct output
      * when all required values are present and only one permission is being

--- a/tests/XMLGenerator/CreateGroupXMLTest.php
+++ b/tests/XMLGenerator/CreateGroupXMLTest.php
@@ -163,7 +163,7 @@ class CreateGroupXMLTest extends TestCase {
                 $group->getNotificationEmails()
             );
         }
-        
+
         self::assertCount(0, $xml->Parameters->Group->Users->children());
 
         self::assertContains('LearningModules', $groupTags);

--- a/tests/XMLGenerator/GetGroupXMLTest.php
+++ b/tests/XMLGenerator/GetGroupXMLTest.php
@@ -34,7 +34,7 @@ class GetGroupXMLTest extends TestCase {
         $query = (new GetGroupQuery())
             ->setAccountApi($accountApi)
             ->setUserApi($userApi);
-        
+
         self::expectException(MissingValueException::class);
         self::expectExceptionMessage(
             'Group identifier must be specified when creating a GetGroupQuery.'

--- a/tests/XMLGenerator/GetUserXMLTest.php
+++ b/tests/XMLGenerator/GetUserXMLTest.php
@@ -33,7 +33,7 @@ class GetUserXMLTest extends TestCase {
         $userApi = 'user';
         $query = (new GetUserQuery())
             ->setMethod('getUser');
-        
+
         self::expectException(MissingValueException::class);
         self::expectExceptionMessage(
             'User identifier must be specified when creating a GetUserQuery.'

--- a/tests/XMLGenerator/ListGroupsXMLTest.php
+++ b/tests/XMLGenerator/ListGroupsXMLTest.php
@@ -36,7 +36,7 @@ class ListGroupsXMLTest extends TestCase {
         $tag = new Tag();
         $query = (new ListGroupsQuery())
             ->setTags([$tag]);
-        
+
         self::expectException(MissingValueException::class);
         self::expectExceptionMessage(
             'Tags must include a tag identifier when creating a ListGroups query.'
@@ -110,7 +110,7 @@ class ListGroupsXMLTest extends TestCase {
             ->setTagName('My Tag')
             ->setTagValues('Tag 2 values');
         $tags = [$tag1, $tag2];
-        
+
         $query = (new ListGroupsQuery())
             ->setGroupName($groupName)
             ->setGroupStatus($groupStatus)
@@ -138,7 +138,7 @@ class ListGroupsXMLTest extends TestCase {
         }
         self::assertCount(1, $parameters);
         self::assertContains('Group', $parameters);
-    
+
         $group = [];
         foreach ($xmlAsElement->Parameters->Group->children() as $groupTag) {
             $group[] = $groupTag->getName();


### PR DESCRIPTION
This PR if accepted does a bit of code tidying. Specifically it eliminates trailing whitespace and whitespace on lines which only have whitespace. Finally, I fixed a few indents which did not match our code style guide.