### PR TITLE
cleanup: correct incorrect license annotations

### DIFF
--- a/src/DataTypes/ErrorCode.php
+++ b/src/DataTypes/ErrorCode.php
@@ -3,11 +3,11 @@
 /**
  * Contains CBS\SmarterU\DataTypes\ErrorCode
  *
- * @author Tom Egan <tom.egan@thecoresolution.com>
+ * @author    Tom Egan <tom.egan@thecoresolution.com>
  * @copyright $year$ Core Business Solutions
- * @license Proprietary
- * @since 2022-12-07
- * @version $version$
+ * @license   MIT
+ * @since     2022-12-07
+ * @version   $version$
  */
 
 declare(strict_types=1);

--- a/src/DataTypes/Group.php
+++ b/src/DataTypes/Group.php
@@ -3,11 +3,11 @@
 /**
  * Contains CBS\SmarterU\DataTypes\Group
  *
- * @author Brian Reich <brian.reich@thecoresolution.com>
+ * @author    Brian Reich <brian.reich@thecoresolution.com>
  * @copyright $year$ Core Business Solutions
- * @license Proprietary
- * @since 2022/08/01
- * @version $version$
+ * @license   MIT
+ * @since     2022/08/01
+ * @version   $version$
  */
 
 declare(strict_types=1);

--- a/src/DataTypes/Tag.php
+++ b/src/DataTypes/Tag.php
@@ -24,7 +24,7 @@ class Tag {
     #region Properties
 
     /**
-     * The ID of the tag. Either the ID or the name must be set when addding
+     * The ID of the tag. Either the ID or the name must be set when adding
      * a tag to a Group.
      */
     protected ?string $tagId = null;

--- a/src/DataTypes/Tag.php
+++ b/src/DataTypes/Tag.php
@@ -3,11 +3,11 @@
 /**
  * Contains CBS\SmarterU\DataTypes\Tag
  *
- * @author Brian Reich <brian.reich@thecoresolution.com>
+ * @author    Brian Reich <brian.reich@thecoresolution.com>
  * @copyright $year$ Core Business Solutions
- * @license Proprietary
- * @since 2022/08/01
- * @version $version$
+ * @license   MIT
+ * @since     2022/08/01
+ * @version   $version$
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
This PR if accepted resolves #24 by correcting license annotations indicating that a source code file uses a proprietary license to indicate that the source code has been released under the MIT license.