### PR TITLE
fix: resolve issue with ampersands in HomeGroup

### DIFF
--- a/example/ListGroupsLiveTest.php
+++ b/example/ListGroupsLiveTest.php
@@ -24,8 +24,8 @@ use CBS\SmarterU\Queries\ListGroupsQuery;
  * This script contains a live test for Client::listGroups.
  */
 
-$accountKey = ''; //insert key here before running
-$userKey = ''; //insert key here before running
+$accountKey = '87CD3F946F81B62242AC4B5E4DC8F59F'; //insert key here before running
+$userKey = '$*376$1w4fk*o!l9cye!9t*3l4!ti4h5at*rb1k1'; //insert key here before running
 
 $query = new ListGroupsQuery();
 

--- a/example/ListGroupsLiveTest.php
+++ b/example/ListGroupsLiveTest.php
@@ -24,8 +24,8 @@ use CBS\SmarterU\Queries\ListGroupsQuery;
  * This script contains a live test for Client::listGroups.
  */
 
-$accountKey = '87CD3F946F81B62242AC4B5E4DC8F59F'; //insert key here before running
-$userKey = '$*376$1w4fk*o!l9cye!9t*3l4!ti4h5at*rb1k1'; //insert key here before running
+$accountKey = ''; //insert key here before running
+$userKey = ''; //insert key here before running
 
 $query = new ListGroupsQuery();
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -628,7 +628,6 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
-
             $errors = $this->getErrorCodesFromXmlElement($bodyAsXml->Errors);
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,

--- a/src/Client.php
+++ b/src/Client.php
@@ -442,9 +442,10 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
+            $errors = $this->getErrorCodesFromXmlElement($bodyAsXml->Errors);
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
+                $errors
             );
         }
 
@@ -627,9 +628,11 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
+
+            $errors = $this->getErrorCodesFromXmlElement($bodyAsXml->Errors);
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
+                $errors
             );
         }
 

--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -181,11 +181,11 @@ class XMLGenerator {
             throw new MissingValueException('Cannot create a User without a Home Group.');
         }
 
-        $profile->addChild('HomeGroup', $user->getHomeGroup());
+        $profile->addChild('HomeGroup', $this->escapeValue($user->getHomeGroup()));
 
         $groups = $userTag->addChild('Groups');
         $groupTag = $groups->addChild('Group');
-        $groupTag->addChild('GroupName', $user->getHomeGroup());
+        $groupTag->addChild('GroupName', $this->escapeValue($user->getHomeGroup()));
         $groupPermissions = $groupTag->addChild('GroupPermissions');
 
         $venues = $userTag->addChild('Venues');
@@ -481,7 +481,7 @@ class XMLGenerator {
             );
         }
         if (!empty($user->getHomeGroup())) {
-            $profile->addChild('HomeGroup', $user->getHomeGroup());
+            $profile->addChild('HomeGroup', $this->escapeValue($user->getHomeGroup()));
         }
         $groups = $userTag->addChild('Groups');
 
@@ -1323,5 +1323,21 @@ class XMLGenerator {
             || !empty($query->getLastAccessedDates())
             || !empty($query->getStartedDates())
         );
+    }
+
+    /**
+     * Escapes a value for legal passthrough to addChild().
+     * 
+     * The documentation stinks on this point but if you dig far enough you
+     * will discover that addChild() will escape < and > when you pass a value
+     * in but it will NOT escape &.  This method will escape & making a value
+     * legal to pass-through to addChild().
+     *
+     * @see https://www.php.net/manual/en/simplexmlelement.addchild.php
+     * @param string $data The string to wrap in a CDATA tag.
+     * @return string The string wrapped in a CDATA tag.
+     */
+    private function escapeValue(string $data): string {
+        return str_replace('&', '&amp;', $data);
     }
 }

--- a/tests/XMLGenerator/CreateUserXMLTest.php
+++ b/tests/XMLGenerator/CreateUserXMLTest.php
@@ -401,44 +401,10 @@ class CreateUserXMLTest extends TestCase {
     /**
      * Tests that the XML generation process for a CreateUser request produces
      * the expected output when all required and optional information is present.
+     *
+     * @dataProvider validUserDataProvider
      */
-    public function testCreateUserProducesExpectedOutputWithAllInfo() {
-        $user = (new User())
-            ->setId('1')
-            ->setEmail('phpunit@test.com')
-            ->setEmployeeId('1')
-            ->setGivenName('PHP')
-            ->setSurname('Unit')
-            ->setPassword('password')
-            ->setTimezone('EST')
-            ->setLearnerNotifications(true)
-            ->setSupervisorNotifications(true)
-            ->setSendEmailTo('Self')
-            ->setAlternateEmail('phpunit@test1.com')
-            ->setAuthenticationType('External')
-            ->setSupervisors(['supervisor1', 'supervisor2'])
-            ->setOrganization('organization')
-            ->setTeams(['team1', 'team2'])
-            ->setLanguage('English')
-            ->setStatus('Active')
-            ->setTitle('Title')
-            ->setDivision('division')
-            ->setAllowFeedback(true)
-            ->setPhonePrimary('555-555-5555')
-            ->setPhoneAlternate('555-555-1234')
-            ->setPhoneMobile('555-555-4321')
-            ->setFax('555-555-5432')
-            ->setWebsite('https://localhost')
-            ->setAddress1('123 Main St')
-            ->setAddress2('Apt. 1')
-            ->setCity('Anytown')
-            ->setProvince('Pennsylvania')
-            ->setCountry('United States')
-            ->setPostalCode('12345')
-            ->setSendMailTo('Personal')
-            ->setReceiveNotifications(true)
-            ->setHomeGroup('My Home Group');
-
+    public function testCreateUserProducesExpectedOutputWithAllInfo(User $user) {
         $xmlGenerator = new XMLGenerator();
         $accountApi = 'account';
         $userApi = 'user';
@@ -696,5 +662,84 @@ class CreateUserXMLTest extends TestCase {
             0,
             $xml->Parameters->User->Wages->Children()
         );
+    }
+
+    public function validUserDataProvider(): array {
+        return [
+            // Original Home group used for testing
+            [(new User())
+                ->setId('1')
+                ->setEmail('phpunit@test.com')
+                ->setEmployeeId('1')
+                ->setGivenName('PHP')
+                ->setSurname('Unit')
+                ->setPassword('password')
+                ->setTimezone('EST')
+                ->setLearnerNotifications(true)
+                ->setSupervisorNotifications(true)
+                ->setSendEmailTo('Self')
+                ->setAlternateEmail('phpunit@test1.com')
+                ->setAuthenticationType('External')
+                ->setSupervisors(['supervisor1', 'supervisor2'])
+                ->setOrganization('organization')
+                ->setTeams(['team1', 'team2'])
+                ->setLanguage('English')
+                ->setStatus('Active')
+                ->setTitle('Title')
+                ->setDivision('division')
+                ->setAllowFeedback(true)
+                ->setPhonePrimary('555-555-5555')
+                ->setPhoneAlternate('555-555-1234')
+                ->setPhoneMobile('555-555-4321')
+                ->setFax('555-555-5432')
+                ->setWebsite('https://localhost')
+                ->setAddress1('123 Main St')
+                ->setAddress2('Apt. 1')
+                ->setCity('Anytown')
+                ->setProvince('Pennsylvania')
+                ->setCountry('United States')
+                ->setPostalCode('12345')
+                ->setSendMailTo('Personal')
+                ->setReceiveNotifications(true)
+                ->setHomeGroup('My Home Group')
+            ],
+            [
+                (new User())
+                ->setId('1')
+                ->setEmail('phpunit@test.com')
+                ->setEmployeeId('1')
+                ->setGivenName('PHP')
+                ->setSurname('Unit')
+                ->setPassword('password')
+                ->setTimezone('EST')
+                ->setLearnerNotifications(true)
+                ->setSupervisorNotifications(true)
+                ->setSendEmailTo('Self')
+                ->setAlternateEmail('phpunit@test1.com')
+                ->setAuthenticationType('External')
+                ->setSupervisors(['supervisor1', 'supervisor2'])
+                ->setOrganization('organization')
+                ->setTeams(['team1', 'team2'])
+                ->setLanguage('English')
+                ->setStatus('Active')
+                ->setTitle('Title')
+                ->setDivision('division')
+                ->setAllowFeedback(true)
+                ->setPhonePrimary('555-555-5555')
+                ->setPhoneAlternate('555-555-1234')
+                ->setPhoneMobile('555-555-4321')
+                ->setFax('555-555-5432')
+                ->setWebsite('https://localhost')
+                ->setAddress1('123 Main St')
+                ->setAddress2('Apt. 1')
+                ->setCity('Anytown')
+                ->setProvince('Pennsylvania')
+                ->setCountry('United States')
+                ->setPostalCode('12345')
+                ->setSendMailTo('Personal')
+                ->setReceiveNotifications(true)
+                ->setHomeGroup('A, B & C Industries')
+            ]
+        ];
     }
 }


### PR DESCRIPTION
If approved, this resolves a bug discovered in which we could not add a user to a group with an ampersand in their name.

The underlying issue is that `SimpleXML::addChild()` escapes `<` and `>` but not `&` and so we were creating malformed XML which, when rendered as text, had an empty `<HomeGroup/>`.  Note that this is a laser-focused solution on our problem but does point out that we should either add the same fix everywhere `addChild()` is called or reimplement `Client` using `DOMDocument` in the future.

Fixes #31 