### PR TITLE
fix: include Email when SendEmailTo is Self

### DIFF
--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -357,10 +357,15 @@ class XMLGenerator {
                 );
             }
         }
+
+        // If the email address is being changed, or if the SendEmailTo field
+        // is set to 'Self', then the new email address must be included in
+        // the request.
         $info = $userTag->addChild('Info');
-        if (!empty($user->getOldEmail())) {
+        if (!empty($user->getOldEmail()) || $user->getSendEmailTo() == 'Self') {
             $info->addChild('Email', $user->getEmail());
         }
+        
         if (!empty($user->getOldEmployeeId())) {
             $info->addChild('EmployeeID', $user->getEmployeeId());
         }

--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -36,6 +36,9 @@ class XMLGenerator {
      */
     private const ROOT_NODE_XML_STRING = '<SmarterU></SmarterU>';
 
+    /** Error when updateUser called with SendEmailTo Self and no email address. */
+    public const ERROR_EMAIL_REQUIRED_FOR_SEND_EMAIL_TO_SELF = 'Email is required when SendEmailTo is set to Self';
+
     /**
      * Generate the XML body for a createUser query.
      *
@@ -333,6 +336,7 @@ class XMLGenerator {
         string $userApi,
         User $user
     ): string {
+        $this->validateUpdateUser($user);
         $xml = simplexml_load_string(self::ROOT_NODE_XML_STRING);
         $xml->addChild('AccountAPI', $accountApi);
         $xml->addChild('UserAPI', $userApi);
@@ -498,6 +502,26 @@ class XMLGenerator {
         return $xml->asXML();
     }
 
+    /**
+     * Sanity-check's a User object before using it to generate XML for an
+     * updateUser request.
+     *
+     * The following checks are implemented:
+     *
+     * 1. If the User's SendEmailTo is set to Self, then the User's Email must
+     *     be set. Otherwise, a MissingValueException is thrown. See
+     *     https://support.smarteru.com/docs/api-updateuser#sendemailto-optional
+     *     for details.
+     *
+     * @throws MissingValueException If the User is missing a required value.
+     */
+    public function validateUpdateUser(User $user) {
+
+        if ($user->getSendEmailTo() === 'Self' && empty($user->getEmail())) {
+            throw new MissingValueException(self::ERROR_EMAIL_REQUIRED_FOR_SEND_EMAIL_TO_SELF);
+        }
+    }
+    
     /**
      * Generate the XML body for a createGroup query.
      *

--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -358,17 +358,11 @@ class XMLGenerator {
             }
         }
 
-        // If the email address is being changed, or if the SendEmailTo field
-        // is set to 'Self', then the new email address must be included in
-        // the request.
         $info = $userTag->addChild('Info');
-        if (!empty($user->getOldEmail()) || $user->getSendEmailTo() == 'Self') {
-            $info->addChild('Email', $user->getEmail());
-        }
-        
-        if (!empty($user->getOldEmployeeId())) {
-            $info->addChild('EmployeeID', $user->getEmployeeId());
-        }
+       
+        $info->addChild('Email', (string) $user->getEmail());
+        $info->addChild('EmployeeID', (string) $user->getEmployeeId());
+
         if (!empty($user->getGivenName())) {
             $info->addChild('GivenName', $user->getGivenName());
         }

--- a/tests/XMLGenerator/CreateUserXMLTest.php
+++ b/tests/XMLGenerator/CreateUserXMLTest.php
@@ -704,6 +704,8 @@ class CreateUserXMLTest extends TestCase {
     }
 
     public function validUserDataProvider(): array {
+        $timezone = Timezone::fromProvidedName('EST');
+
         return [
             // Original Home group used for testing
             [(new User())
@@ -713,7 +715,7 @@ class CreateUserXMLTest extends TestCase {
                 ->setGivenName('PHP')
                 ->setSurname('Unit')
                 ->setPassword('password')
-                ->setTimezone('EST')
+                ->setTimezone($timezone)
                 ->setLearnerNotifications(true)
                 ->setSupervisorNotifications(true)
                 ->setSendEmailTo('Self')
@@ -750,7 +752,7 @@ class CreateUserXMLTest extends TestCase {
                 ->setGivenName('PHP')
                 ->setSurname('Unit')
                 ->setPassword('password')
-                ->setTimezone('EST')
+                ->setTimezone($timezone)
                 ->setLearnerNotifications(true)
                 ->setSupervisorNotifications(true)
                 ->setSendEmailTo('Self')

--- a/tests/XMLGenerator/UpdateUserXMLTest.php
+++ b/tests/XMLGenerator/UpdateUserXMLTest.php
@@ -183,6 +183,23 @@ class UpdateUserXMLTest extends TestCase {
     }
 
     /**
+     * Verifieshat updateUser() throws a MissingValueException when the email
+     * address is not set but SendEmailTo is set to 'Self'.
+     */
+    public function testUpdateUserThrowsMissingValueExceptionWhenSendEmailToIsSelfAndNoEmailSet() {
+        $user = (new User())
+            ->setEmail(null)
+            ->setSendEmailTo('Self');
+
+        $this->assertEmpty($user->getEmail());
+        $this->assertEquals('Self', $user->getSendEmailTo());
+
+        $this->expectException(MissingValueException::class);
+        $this->expectExceptionMessage(XmlGenerator::ERROR_EMAIL_REQUIRED_FOR_SEND_EMAIL_TO_SELF);
+        (new XMLGenerator())->updateUser('account', 'user', $user);
+    }
+
+    /**
      * Tests that the XML generation process for an updateUser request produces
      * the expected output when all required and optional information is present.
      */

--- a/tests/XMLGenerator/UpdateUserXMLTest.php
+++ b/tests/XMLGenerator/UpdateUserXMLTest.php
@@ -118,7 +118,7 @@ class UpdateUserXMLTest extends TestCase {
         foreach ($xml->Parameters->User->Info->children() as $info) {
             $infoTag[] = $info->getName();
         }
-        self::assertCount(5, $infoTag);
+        self::assertCount(6, $infoTag);
         self::assertContains('Email', $infoTag);
         self::assertEquals(
             $user->getEmail(),
@@ -280,7 +280,7 @@ class UpdateUserXMLTest extends TestCase {
         foreach ($xml->Parameters->User->Info->children() as $info) {
             $infoTag[] = $info->getName();
         }
-        self::assertCount(8, $infoTag);
+        self::assertCount(10, $infoTag);
         self::assertContains('GivenName', $infoTag);
         self::assertEquals(
             $user->getGivenName(),


### PR DESCRIPTION
If approved, this hotfix makes a simple change to the SmarterU client library to resolve an issue I discovered while updating an existing user account.

When you call `updateUser`, if  your XML specifies a value of `Self` in `SendEmailTo` then you **MUST** specify `<Info><Email>` regardless of whether you actually need to chanage the value. 