### PR TITLE
fix: escape group name so ampersands stop breaking createGroup

### DIFF
--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -545,7 +545,7 @@ class XMLGenerator {
         $xml->addChild('Method', 'createGroup');
         $parameters = $xml->addChild('Parameters');
         $groupTag = $parameters->addChild('Group');
-        $groupTag->addChild('Name', $group->getName());
+        $groupTag->addChild('Name', $this->escapeValue($group->getName()));
         if (!empty($group->getGroupId())) {
             $groupTag->addChild('GroupID', $group->getGroupId());
         }


### PR DESCRIPTION
If approved, this PR resolves the issue with ampersands in group names causing `createGroup()` to fail.  The fix has been validated in `test1`.