### PR TITLE
fix: AllowFeedback is 1 or 0 (LOG-4434866293)

### DIFF
--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -133,7 +133,7 @@ class XMLGenerator {
         if (!empty($user->getAllowFeedback())) {
             $profile->addChild(
                 'AllowFeedback',
-                $user->getAllowFeedback() ? 'True' : 'False'
+                $user->getAllowFeedback() ? '1' : '0'
             );
         }
         if (!empty($user->getPhonePrimary())) {
@@ -436,7 +436,7 @@ class XMLGenerator {
         if (!empty($user->getAllowFeedback())) {
             $profile->addChild(
                 'AllowFeedback',
-                $user->getAllowFeedback() ? 'True' : 'False'
+                $user->getAllowFeedback() ? '1' : '0'
             );
         }
         if (!empty($user->getPhonePrimary())) {

--- a/tests/XMLGenerator/CreateUserXMLTest.php
+++ b/tests/XMLGenerator/CreateUserXMLTest.php
@@ -599,7 +599,7 @@ class CreateUserXMLTest extends TestCase {
         );
         self::assertContains('AllowFeedback', $profileTag);
         self::assertEquals(
-            $user->getAllowFeedback() ? 'True' : 'False',
+            $user->getAllowFeedback() ? '1' : '0',
             $xml->Parameters->User->Profile->AllowFeedback
         );
         self::assertContains('PhonePrimary', $profileTag);

--- a/tests/XMLGenerator/UpdateUserXMLTest.php
+++ b/tests/XMLGenerator/UpdateUserXMLTest.php
@@ -391,7 +391,7 @@ class UpdateUserXMLTest extends TestCase {
         );
         self::assertContains('AllowFeedback', $profileTag);
         self::assertEquals(
-            $user->getAllowFeedback() ? 'True' : 'False',
+            $user->getAllowFeedback() ? '1' : '0',
             $xml->Parameters->User->Profile->AllowFeedback
         );
         self::assertContains('PhonePrimary', $profileTag);


### PR DESCRIPTION
If approved, this PR resolves the issue from LOG-4434866293 which was caused by an implementation based on faulty documentation. `AllowFeedback` does not expect `True` or `False`. It expects `1` or `0`.