### PR TITLE
feat: better exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ will be thrown, and any error(s) returned by the SmarterU API will be listed in
 the exception message. A list of all possible SmarterU errors can be found
 [here](https://support.smarteru.com/docs/api-error-codes).
 
+## Logging
+
+This library uses the `psr/log` library to log information about failed requests
+to a logger of your choosing.  If an instance of `Psr\Log\LoggerInterface` is
+inject using `Client::setLogger()` then any failed requests will be logged and
+a sanitized version of the request and response will be sent to the logger.
+
 ## Contributing
 
 If you would like to make a contribution to this library, you may do so using

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^7.0",
-        "ext-SimpleXML": "*"
+        "ext-SimpleXML": "*",
+        "psr/log": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "9.5",

--- a/src/Client.php
+++ b/src/Client.php
@@ -256,7 +256,9 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
+                $xml,
+                (string) $response->getBody()
             );
         }
 
@@ -357,7 +359,9 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
+                $xml,
+                (string) $response->getBody()
             );
         }
 
@@ -446,7 +450,9 @@ class Client {
             $errors = $this->getErrorCodesFromXmlElement($bodyAsXml->Errors);
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $errors
+                $errors,
+                $xml,
+                (string) $response->getBody()
             );
         }
 
@@ -548,7 +554,9 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
+                $xml,
+                (string) $response->getBody()
             );
         }
 
@@ -633,7 +641,9 @@ class Client {
             $errors = $this->getErrorCodesFromXmlElement($bodyAsXml->Errors);
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $errors
+                $errors,
+                $xml,
+                (string) $response->getBody()
             );
         }
 
@@ -698,7 +708,9 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
+                $xml,
+                (string) $response->getBody()
             );
         }
 
@@ -807,6 +819,8 @@ class Client {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
+                $xml,
+                (string) $response->getBody()
             );
         }
 
@@ -999,7 +1013,9 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
+                $xml,
+                (string) $response->getBody()
             );
         }
 
@@ -1202,7 +1218,9 @@ class Client {
 
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $errors
+                $,
+                $xml,
+                (string) $response->getBody()
             );
         }
 
@@ -1307,7 +1325,9 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
+                $xml,
+                (string) $response->getBody()
             );
         }
 
@@ -1369,7 +1389,9 @@ class Client {
 
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $errors
+                $errors,
+                $xml,
+                (string) $response->getBody()
             );
         }
 
@@ -1449,7 +1471,9 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
+                $xml,
+                (string) $response->getBody()
             );
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -256,9 +256,7 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
-                $xml,
-                (string) $response->getBody()
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
             );
         }
 
@@ -359,9 +357,7 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
-                $xml,
-                (string) $response->getBody()
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
             );
         }
 
@@ -450,9 +446,7 @@ class Client {
             $errors = $this->getErrorCodesFromXmlElement($bodyAsXml->Errors);
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $errors,
-                $xml,
-                (string) $response->getBody()
+                $errors
             );
         }
 
@@ -554,9 +548,7 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
-                $xml,
-                (string) $response->getBody()
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
             );
         }
 
@@ -641,9 +633,7 @@ class Client {
             $errors = $this->getErrorCodesFromXmlElement($bodyAsXml->Errors);
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $errors,
-                $xml,
-                (string) $response->getBody()
+                $errors
             );
         }
 
@@ -708,9 +698,7 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
-                $xml,
-                (string) $response->getBody()
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
             );
         }
 
@@ -818,9 +806,7 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
-                $xml,
-                (string) $response->getBody()
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
             );
         }
 
@@ -1013,9 +999,7 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
-                $xml,
-                (string) $response->getBody()
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
             );
         }
 
@@ -1218,9 +1202,7 @@ class Client {
 
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
-                $xml,
-                (string) $response->getBody()
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
             );
         }
 
@@ -1325,9 +1307,7 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
-                $xml,
-                (string) $response->getBody()
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
             );
         }
 
@@ -1471,9 +1451,7 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
-                $xml,
-                (string) $response->getBody()
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
             );
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -32,7 +32,6 @@ use DateTime;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\ClientException;
 use Psr\Log\LoggerAwareTrait;
-use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 
 /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -1202,7 +1202,7 @@ class Client {
 
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
+                $errors
             );
         }
 
@@ -1369,9 +1369,7 @@ class Client {
 
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $errors,
-                $xml,
-                (string) $response->getBody()
+                $errors
             );
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -262,7 +262,7 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
-            
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
@@ -364,6 +364,7 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
@@ -453,6 +454,7 @@ class Client {
 
         if ((string) $bodyAsXml->Result === 'Failed') {
             $errors = $this->getErrorCodesFromXmlElement($bodyAsXml->Errors);
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $errors
@@ -555,6 +557,7 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
@@ -640,6 +643,7 @@ class Client {
 
         if ((string) $bodyAsXml->Result === 'Failed') {
             $errors = $this->getErrorCodesFromXmlElement($bodyAsXml->Errors);
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $errors
@@ -705,6 +709,7 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
@@ -761,6 +766,7 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
@@ -813,6 +819,7 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
@@ -886,6 +893,7 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
@@ -959,6 +967,7 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
@@ -1006,6 +1015,7 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
@@ -1209,6 +1219,7 @@ class Client {
                 }
             }
 
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $errors
@@ -1314,6 +1325,7 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
@@ -1376,6 +1388,7 @@ class Client {
                 }
             }
 
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $errors
@@ -1456,6 +1469,7 @@ class Client {
         $bodyAsXml = simplexml_load_string((string) $response->getBody());
 
         if ((string) $bodyAsXml->Result === 'Failed') {
+            $this->logFailedRequest($xml, (string) $response->getBody());
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
                 $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)

--- a/src/Client.php
+++ b/src/Client.php
@@ -32,6 +32,8 @@ use DateTime;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\ClientException;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use SimpleXMLElement;
 
 /**
@@ -132,13 +134,16 @@ class Client {
      *      You must set the user API key via the constructor or
      *      `setUserApi` before invoking methods which interact with the
      *      SmarterU API
+     * @param LoggerInterface|null $logger The logger used to record API errors.
      */
     public function __construct(
         string $apiKey,
-        string $apiUserKey
+        string $apiUserKey,
+        ?LoggerInterface $logger = null
     ) {
         $this->setAccountApi($apiKey);
         $this->setUserApi($apiUserKey);
+        $this->setLogger($logger ?? new NullLogger());
     }
 
     /**
@@ -1507,11 +1512,6 @@ class Client {
      * @param string $response The XML response that was received.
      */
     private function logFailedRequest(string $request, string $response) {
-        // If client doesn't have a logger, there is nothing more to do here.
-        if ($this->logger === null) {
-            return;
-        }
-
         // Scrub AccountAPI key so we don't expose a secret in logs.
         $sanitizedRequest = preg_replace(
             '/<AccountAPI>.*<\/AccountAPI>/',

--- a/src/Client.php
+++ b/src/Client.php
@@ -1506,12 +1506,12 @@ class Client {
     }
 
     /**
-     * Logs a failed request.
+     * Accepts a request XML string and sanitizes it for logging purposes.
      *
-     * @param string $request The XML request that failed.
-     * @param string $response The XML response that was received.
+     * @param string $request The XML request to sanitize.
+     * @return string The sanitized XML request.
      */
-    private function logFailedRequest(string $request, string $response) {
+    public function sanitizeRequestXML(string $request): string {
         // Scrub AccountAPI key so we don't expose a secret in logs.
         $sanitizedRequest = preg_replace(
             '/<AccountAPI>.*<\/AccountAPI>/',
@@ -1526,11 +1526,21 @@ class Client {
             $sanitizedRequest
         );
 
+        return $sanitizedRequest;
+    }
+
+    /**
+     * Logs a failed request.
+     *
+     * @param string $request The XML request that failed.
+     * @param string $response The XML response that was received.
+     */
+    private function logFailedRequest(string $request, string $response) {
         // Log the request and response.
         $this->logger->error(
             'Failed to make request to SmarterU API. See context for request/response details.',
             [
-                'request' => $request,
+                'request' => $this->sanitizeRequestXML($request),
                 'response' => $response
             ]
         );

--- a/src/Client.php
+++ b/src/Client.php
@@ -818,7 +818,7 @@ class Client {
         if ((string) $bodyAsXml->Result === 'Failed') {
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors)
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
                 $xml,
                 (string) $response->getBody()
             );
@@ -1218,7 +1218,7 @@ class Client {
 
             throw new SmarterUException(
                 self::SMARTERU_EXCEPTION_MESSAGE,
-                $,
+                $this->getErrorCodesFromXmlElement($bodyAsXml->Errors),
                 $xml,
                 (string) $response->getBody()
             );

--- a/src/Exceptions/SmarterUException.php
+++ b/src/Exceptions/SmarterUException.php
@@ -30,30 +30,13 @@ class SmarterUException extends \Exception {
     protected array $errorCodes = [];
 
     /**
-     * The request sent to the SmarterU API which resulted in this exception.
-     *
-     * @var string
-     */
-    protected ?string $request = null;
-
-    /**
-     * The response sent to the SmarterU API which resulted in this exception.
-     */
-    protected ?string $response = null;
-
-    /**
      * Create a new exception instance
      *
      * @param string $message  the exception message
      * @param ErrorCode[]  the list of SmarterU error codes which were detected
      *      when the exception was thrown
      */
-    public function __construct(
-        string $message = '',
-        array $errorCodes = [],
-        ?string $request = null,
-        ?string $response = null
-    ) {
+    public function __construct(string $message = '', array $errorCodes = []) {
         parent::__construct($message);
 
         foreach ($errorCodes as $errorCode) {
@@ -61,71 +44,6 @@ class SmarterUException extends \Exception {
                 $this->errorCodes[] = $errorCode;
             }
         }
-
-        $this->setRequest($request);
-        $this->setResponse($response);
-    }
-
-    /**
-     * Set the response XML returned from the SmarterU API which resulted in
-     * this exception.
-     *
-     * @param string $response  the response XML
-     * @return self
-     */
-    public function setResponse(?string $response = null): self {
-        $this->response = $response;
-        return $this;
-    }
-
-    /**
-     * Returns the response XML returned from the SmarterU API which resulted in
-     * this exception.
-     *
-     * @return string  the response XML
-     */
-    public function getResponse(): ?string {
-        return $this->response;
-    }
-
-    /**
-     * Set the request XML sent to the SmarterU API which resulted in this
-     * exception.
-     *
-     * The request ill have the AccountAPI and UserAPI values hidden to prevent
-     * sensitive information from being logged.
-     *
-     * @param string $request  the request XML
-     * @return self
-     */
-    public function setRequest(?string $request = null): self {
-        $this->request = $this->sanitizeRequest($request);
-        return $this;
-    }
-
-    /**
-     * Returns the request XML sent to the SmarterU API which resulted in this
-     * exception.
-     *
-     * @return string  the request XML
-     */
-    public function getRequest(): ?string {
-        return $this->request;
-    }
-
-    /**
-     * Sanitize the request XML to remove sensitive information.
-     *
-     * @param string $request  the request XML
-     * @return string the sanitized request XML
-     */
-    private function sanitizeRequest(?string $request = null): ?string {
-        if (is_string($request)) {
-            $request = preg_replace('/<AccountAPI>.*<\/AccountAPI>/', '<AccountAPI>********</AccountAPI>', $request);
-            $request = preg_replace('/<UserAPI>.*<\/UserAPI>/', '<UserAPI>********</UserAPI>', $request);
-        }
-
-        return $request;
     }
 
     /**
@@ -135,9 +53,7 @@ class SmarterUException extends \Exception {
      */
     public function __toString() {
         $lines = [
-            __CLASS__ . ': ' . $this->message,
-            'Request: ' . $this->getRequest(),
-            'Response: ' . $this->getResponse(),
+            __CLASS__ . ': ' . $this->message
         ];
 
         foreach ($this->errorCodes as $errorCode) {

--- a/src/Exceptions/SmarterUException.php
+++ b/src/Exceptions/SmarterUException.php
@@ -135,7 +135,9 @@ class SmarterUException extends \Exception {
      */
     public function __toString() {
         $lines = [
-            __CLASS__ . ': ' . $this->message
+            __CLASS__ . ': ' . $this->message,
+            'Request: ' . $this->getRequest(),
+            'Response: ' . $this->getResponse(),
         ];
 
         foreach ($this->errorCodes as $errorCode) {

--- a/src/Exceptions/SmarterUException.php
+++ b/src/Exceptions/SmarterUException.php
@@ -119,7 +119,7 @@ class SmarterUException extends \Exception {
      * @param string $request  the request XML
      * @return string the sanitized request XML
      */
-    private function sanitizeRequest(?string $request = null): string {
+    private function sanitizeRequest(?string $request = null): ?string {
         if (is_string($request)) {
             $request = preg_replace('/<AccountAPI>.*<\/AccountAPI>/', '<AccountAPI>********</AccountAPI>', $request);
             $request = preg_replace('/<UserAPI>.*<\/UserAPI>/', '<UserAPI>********</UserAPI>', $request);

--- a/src/Exceptions/SmarterUException.php
+++ b/src/Exceptions/SmarterUException.php
@@ -30,13 +30,30 @@ class SmarterUException extends \Exception {
     protected array $errorCodes = [];
 
     /**
+     * The request sent to the SmarterU API which resulted in this exception.
+     *
+     * @var string
+     */
+    protected ?string $request = null;
+
+    /**
+     * The response sent to the SmarterU API which resulted in this exception.
+     */
+    protected ?string $response = null;
+
+    /**
      * Create a new exception instance
      *
      * @param string $message  the exception message
      * @param ErrorCode[]  the list of SmarterU error codes which were detected
      *      when the exception was thrown
      */
-    public function __construct(string $message = '', array $errorCodes = []) {
+    public function __construct(
+        string $message = '',
+        array $errorCodes = [],
+        ?string $request = null,
+        ?string $response = null
+    ) {
         parent::__construct($message);
 
         foreach ($errorCodes as $errorCode) {
@@ -44,6 +61,71 @@ class SmarterUException extends \Exception {
                 $this->errorCodes[] = $errorCode;
             }
         }
+
+        $this->setRequest($request);
+        $this->setResponse($response);
+    }
+
+    /**
+     * Set the response XML returned from the SmarterU API which resulted in
+     * this exception.
+     *
+     * @param string $response  the response XML
+     * @return self
+     */
+    public function setResponse(?string $response = null): self {
+        $this->response = $response;
+        return $this;
+    }
+
+    /**
+     * Returns the response XML returned from the SmarterU API which resulted in
+     * this exception.
+     *
+     * @return string  the response XML
+     */
+    public function getResponse(): ?string {
+        return $this->response;
+    }
+
+    /**
+     * Set the request XML sent to the SmarterU API which resulted in this
+     * exception.
+     *
+     * The request ill have the AccountAPI and UserAPI values hidden to prevent
+     * sensitive information from being logged.
+     *
+     * @param string $request  the request XML
+     * @return self
+     */
+    public function setRequest(?string $request = null): self {
+        $this->$request = $this->sanitizeRequest($request);
+        return $this;
+    }
+
+    /**
+     * Returns the request XML sent to the SmarterU API which resulted in this
+     * exception.
+     *
+     * @return string  the request XML
+     */
+    public function getRequest(): ?string {
+        return $this->request;
+    }
+
+    /**
+     * Sanitize the request XML to remove sensitive information.
+     *
+     * @param string $request  the request XML
+     * @return string the sanitized request XML
+     */
+    private function sanitizeRequest(?string $request = null): string {
+        if (is_string($request)) {
+            $request = preg_replace('/<AccountAPI>.*<\/AccountAPI>/', '<AccountAPI>********</AccountAPI>', $request);
+            $request = preg_replace('/<UserAPI>.*<\/UserAPI>/', '<UserAPI>********</UserAPI>', $request);
+        }
+
+        return $request;
     }
 
     /**

--- a/src/Exceptions/SmarterUException.php
+++ b/src/Exceptions/SmarterUException.php
@@ -99,7 +99,7 @@ class SmarterUException extends \Exception {
      * @return self
      */
     public function setRequest(?string $request = null): self {
-        $this->$request = $this->sanitizeRequest($request);
+        $this->request = $this->sanitizeRequest($request);
         return $this;
     }
 

--- a/tests/Client/AddUsersToGroupClientTest.php
+++ b/tests/Client/AddUsersToGroupClientTest.php
@@ -284,7 +284,17 @@ class AddUsersToGroupClientTest extends TestCase {
         $handlerStack = HandlerStack::create($mock);
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
-        $client->setHttpClient($httpClient);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>updateGroup</Method><Parameters><Group><Identifier><Name>My Group</Name></Identifier><Users><User><Email>test@test.com</Email><UserAction>Add</UserAction><HomeGroup>0</HomeGroup><Permissions/></User></Users><LearningModules/><SubscriptionVariants/></Group></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/CreateGroupClientTest.php
+++ b/tests/Client/CreateGroupClientTest.php
@@ -299,8 +299,18 @@ class CreateGroupClientTest extends TestCase {
         $handlerStack->push($history);
 
         $httpClient = new HttpClient(['handler' => $handlerStack]);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>createGroup</Method><Parameters><Group><Name>My Group</Name><GroupID>12</GroupID><Status>Active</Status><Description>This is a group created for testing.</Description><HomeGroupMessage>Home Group</HomeGroupMessage><NotificationEmails><NotificationEmail>phpunit@test.com</NotificationEmail><NotificationEmail>test@phpunit.com</NotificationEmail></NotificationEmails><UserHelpOverrideDefault>0</UserHelpOverrideDefault><UserHelpEnabled>1</UserHelpEnabled><UserHelpEmail>phpunit2@test.com,test2@phpunit.com</UserHelpEmail><UserHelpText>Help Message</UserHelpText><Tags2><Tag2><TagID>1</TagID><TagValues>Tag1 values</TagValues></Tag2><Tag2><TagID>2</TagID><TagValues>Tag2 values</TagValues></Tag2></Tags2><UserLimit><Enabled>1</Enabled><Amount>50</Amount></UserLimit><Users/><LearningModules><LearningModule><ID>4</ID><AllowSelfEnroll>1</AllowSelfEnroll><AutoEnroll>0</AutoEnroll></LearningModule><LearningModule><ID>5</ID><AllowSelfEnroll>0</AllowSelfEnroll><AutoEnroll>1</AutoEnroll></LearningModule></LearningModules><SubscriptionVariants><SubscriptionVariant><ID>6</ID><RequiresCredits>1</RequiresCredits></SubscriptionVariant><SubscriptionVariant><ID>7</ID><RequiresCredits>0</RequiresCredits></SubscriptionVariant></SubscriptionVariants><DashboardSetID>8</DashboardSetID></Group></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
 
-        $client->setHttpClient($httpClient);
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/CreateUserClientTest.php
+++ b/tests/Client/CreateUserClientTest.php
@@ -207,8 +207,18 @@ class CreateUserClientTest extends TestCase {
         $handlerStack->push($history);
 
         $httpClient = new HttpClient(['handler' => $handlerStack]);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>createUser</Method><Parameters><User><Info><Email>phpunit@test.com</Email><EmployeeID>1</EmployeeID><GivenName>PHP</GivenName><Surname>Unit</Surname><Password>password</Password><Timezone>EST</Timezone><LearnerNotifications>1</LearnerNotifications><SupervisorNotifications>1</SupervisorNotifications><SendEmailTo>Self</SendEmailTo><AlternateEmail>phpunit@test1.com</AlternateEmail><AuthenticationType>External</AuthenticationType></Info><Profile><Supervisors><Supervisor>supervisor1</Supervisor><Supervisor>supervisor2</Supervisor></Supervisors><Organization>organization</Organization><Teams><Team>team1</Team><Team>team2</Team></Teams><Language>English</Language><Status>Active</Status><Title>Title</Title><Division>division</Division><AllowFeedback>1</AllowFeedback><PhonePrimary>555-555-5555</PhonePrimary><PhoneAlternate>555-555-1234</PhoneAlternate><PhoneMobile>555-555-4321</PhoneMobile><Fax>555-555-5432</Fax><Website>https://localhost</Website><Address1>123 Main St</Address1><Address2>Apt. 1</Address2><City>Anytown</City><Province>Pennsylvania</Province><Country>United States</Country><PostalCode>12345</PostalCode><SendMailTo>Personal</SendMailTo><ReceiveNotifications>1</ReceiveNotifications><HomeGroup>My Home Group</HomeGroup></Profile><Groups><Group><GroupName>My Home Group</GroupName><GroupPermissions/></Group></Groups><Venues/><Wages/></User></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
 
-        $client->setHttpClient($httpClient);
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/GetGroupClientTest.php
+++ b/tests/Client/GetGroupClientTest.php
@@ -301,8 +301,18 @@ class GetGroupClientTest extends TestCase {
         $handlerStack->push($history);
 
         $httpClient = new HttpClient(['handler' => $handlerStack]);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU>\n<AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>getGroup</Method><Parameters><Group><Name>My Group</Name></Group></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
 
-        $client->setHttpClient($httpClient);
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/GetLearnerReportClientTest.php
+++ b/tests/Client/GetLearnerReportClientTest.php
@@ -170,7 +170,18 @@ class GetLearnerReportClientTest extends TestCase {
         $handlerStack = HandlerStack::create($mock);
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
-        $client->setHttpClient($httpClient);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>getLearnerReport</Method><Parameters><Report><Page>1</Page><PageSize>50</PageSize><Filters><EnrollmentID>1</EnrollmentID><Groups><GroupStatus>Active</GroupStatus></Groups><Enrollments/><Users><UserStatus>Active</UserStatus></Users></Filters></Report><Columns/><CustomFields/></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
+
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/GetUserClientTest.php
+++ b/tests/Client/GetUserClientTest.php
@@ -508,8 +508,18 @@ class GetUserClientTest extends TestCase {
         $handlerStack->push($history);
 
         $httpClient = new HttpClient(['handler' => $handlerStack]);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU>\n<AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>getUser</Method><Parameters><User><ID>1</ID></User></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
 
-        $client->setHttpClient($httpClient);
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/GetUserGroupsClientTest.php
+++ b/tests/Client/GetUserGroupsClientTest.php
@@ -309,8 +309,18 @@ class GetUserGroupsClientTest extends TestCase {
         $handlerStack->push($history);
 
         $httpClient = new HttpClient(['handler' => $handlerStack]);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU>\n<AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>getUserGroups</Method><Parameters><User><ID>1</ID></User></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
 
-        $client->setHttpClient($httpClient);
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/GrantPermissionsClientTest.php
+++ b/tests/Client/GrantPermissionsClientTest.php
@@ -327,7 +327,18 @@ class GrantPermissionsClientTest extends TestCase {
         $handlerStack = HandlerStack::create($mock);
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
-        $client->setHttpClient($httpClient);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>updateUser</Method><Parameters><User><Identifier><Email>test@test.com</Email></Identifier><Info/><Profile/><Groups><Group><GroupName>My Group</GroupName><GroupAction>Add</GroupAction><GroupPermissions><Permission><Action>Grant</Action><Code>MANAGE_GROUP</Code></Permission></GroupPermissions></Group></Groups><Venues/><Wages/></User></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
+
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/ListGroupsClientTest.php
+++ b/tests/Client/ListGroupsClientTest.php
@@ -276,8 +276,18 @@ class ListGroupsClientTest extends TestCase {
         $handlerStack->push($history);
 
         $httpClient = new HttpClient(['handler' => $handlerStack]);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU>\n<AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>listGroups</Method><Parameters><Group><Filters/></Group></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
 
-        $client->setHttpClient($httpClient);
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/ListUsersClientTest.php
+++ b/tests/Client/ListUsersClientTest.php
@@ -364,8 +364,18 @@ class ListUsersClientTest extends TestCase {
         $handlerStack->push($history);
 
         $httpClient = new HttpClient(['handler' => $handlerStack]);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU>\n<AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>listUsers</Method><Parameters><User><Page>1</Page><PageSize>50</PageSize><Filters><UserStatus>Active</UserStatus></Filters></User></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
 
-        $client->setHttpClient($httpClient);
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/RemoveUsersFromGroupClientTest.php
+++ b/tests/Client/RemoveUsersFromGroupClientTest.php
@@ -285,7 +285,18 @@ class RemoveUsersFromGroupClientTest extends TestCase {
         $handlerStack = HandlerStack::create($mock);
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
-        $client->setHttpClient($httpClient);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>updateGroup</Method><Parameters><Group><Identifier><Name>My Group</Name></Identifier><Users><User><Email>test@test.com</Email><UserAction>Remove</UserAction><HomeGroup>0</HomeGroup><Permissions/></User></Users><LearningModules/><SubscriptionVariants/></Group></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
+
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/RequestExternalAuthorizationClientTest.php
+++ b/tests/Client/RequestExternalAuthorizationClientTest.php
@@ -153,7 +153,18 @@ class RequestExternalAuthorizationClientTest extends TestCase {
         $handlerStack = HandlerStack::create($mock);
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
-        $client->setHttpClient($httpClient);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>requestExternalAuthorization</Method><Parameters><Security><Email>test@test.com</Email></Security></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
+
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/RevokePermissionsClientTest.php
+++ b/tests/Client/RevokePermissionsClientTest.php
@@ -327,7 +327,18 @@ class RevokePermissionsClientTest extends TestCase {
         $handlerStack = HandlerStack::create($mock);
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
-        $client->setHttpClient($httpClient);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>updateUser</Method><Parameters><User><Identifier><Email>test@test.com</Email></Identifier><Info/><Profile/><Groups><Group><GroupName>My Group</GroupName><GroupAction>Add</GroupAction><GroupPermissions><Permission><Action>Deny</Action><Code>MANAGE_GROUP</Code></Permission></GroupPermissions></Group></Groups><Venues/><Wages/></User></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
+
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/UpdateGroupClientTest.php
+++ b/tests/Client/UpdateGroupClientTest.php
@@ -302,8 +302,18 @@ class UpdateGroupClientTest extends TestCase {
         $handlerStack->push($history);
 
         $httpClient = new HttpClient(['handler' => $handlerStack]);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>updateGroup</Method><Parameters><Group><Identifier><Name>My Group</Name></Identifier><Status>Active</Status><Description>This is a group created for testing.</Description><HomeGroupMessage>Home Group</HomeGroupMessage><NotificationEmails><NotificationEmail>phpunit@test.com</NotificationEmail><NotificationEmail>test@phpunit.com</NotificationEmail></NotificationEmails><UserHelpOverrideDefault>0</UserHelpOverrideDefault><UserHelpEnabled>1</UserHelpEnabled><UserHelpEmail>phpunit2@test.com,test2@phpunit.com</UserHelpEmail><UserHelpText>Help Message</UserHelpText><Tags2><Tag2><TagID>1</TagID><TagValues>Tag1 values</TagValues></Tag2><Tag2><TagID>2</TagID><TagValues>Tag2 values</TagValues></Tag2></Tags2><UserLimit><Enabled>1</Enabled><Amount>50</Amount></UserLimit><Users/><LearningModules><LearningModule><ID>4</ID><LearningModuleAction>Add</LearningModuleAction><AllowSelfEnroll>1</AllowSelfEnroll><AutoEnroll>0</AutoEnroll></LearningModule><LearningModule><ID>5</ID><LearningModuleAction>Remove</LearningModuleAction><AllowSelfEnroll>0</AllowSelfEnroll><AutoEnroll>1</AutoEnroll></LearningModule></LearningModules><SubscriptionVariants><SubscriptionVariant><ID>6</ID><SubscriptionVariantAction>Add</SubscriptionVariantAction><RequiresCredits>1</RequiresCredits></SubscriptionVariant><SubscriptionVariant><ID>7</ID><SubscriptionVariantAction>Remove</SubscriptionVariantAction><RequiresCredits>0</RequiresCredits></SubscriptionVariant></SubscriptionVariants><DashboardSetID>8</DashboardSetID></Group></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
 
-        $client->setHttpClient($httpClient);
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Client/UpdateUserClientTest.php
+++ b/tests/Client/UpdateUserClientTest.php
@@ -312,8 +312,18 @@ class UpdateUserClientTest extends TestCase {
         $handlerStack->push($history);
 
         $httpClient = new HttpClient(['handler' => $handlerStack]);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
+            $this->identicalTo([
+                'request' => "<?xml version=\"1.0\"?>\n<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>updateUser</Method><Parameters><User><Identifier><Email>phpunit@test.com</Email></Identifier><Info><Email>phpunit@test.com</Email><EmployeeID>1</EmployeeID><GivenName>PHP</GivenName><Surname>Unit</Surname><Timezone>EST</Timezone><LearnerNotifications>1</LearnerNotifications><SupervisorNotifications>1</SupervisorNotifications><SendEmailTo>Self</SendEmailTo><AlternateEmail>phpunit@test1.com</AlternateEmail><AuthenticationType>External</AuthenticationType></Info><Profile><Supervisors><Supervisor>supervisor1</Supervisor><Supervisor>supervisor2</Supervisor></Supervisors><Organization>organization</Organization><Teams><Team>team1</Team><Team>team2</Team></Teams><Language>English</Language><Status>Active</Status><Title>Title</Title><Division>division</Division><AllowFeedback>1</AllowFeedback><PhonePrimary>555-555-5555</PhonePrimary><PhoneAlternate>555-555-1234</PhoneAlternate><PhoneMobile>555-555-4321</PhoneMobile><Fax>555-555-5432</Fax><Website>https://localhost</Website><Address1>123 Main St</Address1><Address2>Apt. 1</Address2><City>Anytown</City><Province>Pennsylvania</Province><Country>United States</Country><PostalCode>12345</PostalCode><SendMailTo>Personal</SendMailTo><ReceiveNotifications>1</ReceiveNotifications><HomeGroup>My Home Group</HomeGroup></Profile><Groups/><Venues/><Wages/></User></Parameters></SmarterU>\n",
+                'response' => $body
+            ])
+        );
 
-        $client->setHttpClient($httpClient);
+        $client
+            ->setHttpClient($httpClient)
+            ->setLogger($logger);
 
         // Make the request. Because we want to inspect custom exception
         // properties we'll handle the try/catch/cache of the exception

--- a/tests/Exceptions/SmarterUExceptionTest.php
+++ b/tests/Exceptions/SmarterUExceptionTest.php
@@ -24,8 +24,6 @@ class SmarterUExceptionTest extends TestCase {
     public function testAgreement() {
         $code = 'SU:01';
         $message = 'No POST data detected';
-        $request = '<SmarterU><AccountAPI>12345</AccountAPI><UserAPI>password</UserAPI><Method>updateUser</Method><Parameters><User><Identifier><Email>ryan.davis@thecoresolution.com</Email></Identifier><Info><Email>ryan.davis@thecoresolution.com</Email><EmployeeID/><GivenName>Ryann</GivenName></Info><Profile><Status>Active</Status><ReceiveNotifications>1</ReceiveNotifications></Profile><Groups/><Venues/><Wages/></User></Parameters></SmarterU>';
-        $response = '<SmarterU><Result>Failed</Result><Info/><Errors><Error><ErrorID>UU:69</ErrorID><ErrorMessage>The requested user cannot be updated via the API.</ErrorMessage></Error></Errors></SmarterU>';
         $errorCode = new ErrorCode($code, $message);
 
         $exception = new SmarterUException($message, [$errorCode], $request, $response);
@@ -36,10 +34,7 @@ class SmarterUExceptionTest extends TestCase {
         self::assertCount(1, $errorCodes);
 
         $errorCode = reset($errorCodes);
-        $expectedRequest = '<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>updateUser</Method><Parameters><User><Identifier><Email>ryan.davis@thecoresolution.com</Email></Identifier><Info><Email>ryan.davis@thecoresolution.com</Email><EmployeeID/><GivenName>Ryann</GivenName></Info><Profile><Status>Active</Status><ReceiveNotifications>1</ReceiveNotifications></Profile><Groups/><Venues/><Wages/></User></Parameters></SmarterU>';
         self::assertEquals($code, $errorCode->getErrorCode());
         self::assertEquals($message, $errorCode->getErrorMessage());
-        self::assertEquals($expectedRequest, $exception->getRequest());
-        self::assertEquals($response, $exception->getResponse());
     }
 }

--- a/tests/Exceptions/SmarterUExceptionTest.php
+++ b/tests/Exceptions/SmarterUExceptionTest.php
@@ -26,7 +26,7 @@ class SmarterUExceptionTest extends TestCase {
         $message = 'No POST data detected';
         $errorCode = new ErrorCode($code, $message);
 
-        $exception = new SmarterUException($message, [$errorCode], $request, $response);
+        $exception = new SmarterUException($message, [$errorCode]);
 
         self::assertEquals($message, $exception->getMessage());
         $errorCodes = $exception->getErrorCodes();

--- a/tests/Exceptions/SmarterUExceptionTest.php
+++ b/tests/Exceptions/SmarterUExceptionTest.php
@@ -24,10 +24,11 @@ class SmarterUExceptionTest extends TestCase {
     public function testAgreement() {
         $code = 'SU:01';
         $message = 'No POST data detected';
-
+        $request = '<SmarterU><AccountAPI>12345</AccountAPI><UserAPI>password</UserAPI><Method>updateUser</Method><Parameters><User><Identifier><Email>ryan.davis@thecoresolution.com</Email></Identifier><Info><Email>ryan.davis@thecoresolution.com</Email><EmployeeID/><GivenName>Ryann</GivenName></Info><Profile><Status>Active</Status><ReceiveNotifications>1</ReceiveNotifications></Profile><Groups/><Venues/><Wages/></User></Parameters></SmarterU>';
+        $response = '<SmarterU><Result>Failed</Result><Info/><Errors><Error><ErrorID>UU:69</ErrorID><ErrorMessage>The requested user cannot be updated via the API.</ErrorMessage></Error></Errors></SmarterU>';
         $errorCode = new ErrorCode($code, $message);
 
-        $exception = new SmarterUException($message, [$errorCode]);
+        $exception = new SmarterUException($message, [$errorCode], $request, $response);
 
         self::assertEquals($message, $exception->getMessage());
         $errorCodes = $exception->getErrorCodes();
@@ -35,7 +36,10 @@ class SmarterUExceptionTest extends TestCase {
         self::assertCount(1, $errorCodes);
 
         $errorCode = reset($errorCodes);
+        $expectedRequest = '<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>updateUser</Method><Parameters><User><Identifier><Email>ryan.davis@thecoresolution.com</Email></Identifier><Info><Email>ryan.davis@thecoresolution.com</Email><EmployeeID/><GivenName>Ryann</GivenName></Info><Profile><Status>Active</Status><ReceiveNotifications>1</ReceiveNotifications></Profile><Groups/><Venues/><Wages/></User></Parameters></SmarterU>';
         self::assertEquals($code, $errorCode->getErrorCode());
         self::assertEquals($message, $errorCode->getErrorMessage());
+        self::assertEquals($expectedRequest, $exception->getRequest());
+        self::assertEquals($response, $exception->getResponse());
     }
 }


### PR DESCRIPTION
If approved this PR:

1. Adds a dependency on `psr/log`
2. Adds a private method `logFailedRequest` to `Client` which, if a logger is present, logs the failed request/response.
3. Adds a call to `logFailedRequest()` everywhere a `SmarterUException` is thrown.

With this change in place, we can actually capture information we need to troubleshoot integration issues.

One thing you might wonder about is, why am I not testing that the logger gets data when a failure occurs?  The reason is because `psr/log` doesn't ship a test logger, only `NullLogger`, which is a "no-op" implementation that I cannot expect to validate log events.
