### PR TITLE
fix: test and cleanup learner report

### DIFF
--- a/example/GetEnrollmentReportLiveTest.php
+++ b/example/GetEnrollmentReportLiveTest.php
@@ -3,6 +3,11 @@
 /**
  * A live Enrollment Report test.
  *
+ * This test expects the SMARTERU_ACCOUNT_KEY and SMARTERU_USER_KEY environment
+ * variables to be set. It will query the SMARTERU API for a list of all users
+ * in the SANDBOX group that are active and output their progress in the
+ * courses they are enrolled in, in CSV format.
+ *
  * @copyright   $year$ Core Business Solutions
  * @license     MIT
  * @version     $version$
@@ -15,15 +20,9 @@ namespace CBS\SmarterU\Tests\Usability;
 require_once(__DIR__ . '/../vendor/autoload.php');
 
 use CBS\SmarterU\Client;
-use CBS\SmarterU\DataTypes\User;
-use CBS\SmarterU\DataTypes\Timezone;
 use CBS\SmarterU\Exceptions\SmarterUException;
 use CBS\SmarterU\Queries\GetLearnerReportQuery;
 
-/**
- * This script contains a live test for Client::createUser. It was used to
- * intentionally trigger errors and see how the API responds.
- */
 $accountKey = getenv('SMARTERU_ACCOUNT_KEY') ?? 'No Account Key Provided';
 $userKey = getenv('SMARTERU_USER_KEY') ?? 'No User Key Provided';
 
@@ -31,7 +30,8 @@ try {
     // Create the Client for speaking to the API
     $client = new Client($accountKey, $userKey);
     
-    // Create the user
+    // Query for an Enrollment report for all users in our SANDBOX group
+    // that are active. Add some optional fields that we care about.
     $results = $client->getLearnerReport(
         (new GetLearnerReportQuery())
             ->setGroupNames(['SANDBOX - Core Business Solutions'])

--- a/example/GetEnrollmentReportLiveTest.php
+++ b/example/GetEnrollmentReportLiveTest.php
@@ -23,8 +23,27 @@ use CBS\SmarterU\Client;
 use CBS\SmarterU\Exceptions\SmarterUException;
 use CBS\SmarterU\Queries\GetLearnerReportQuery;
 
-$accountKey = getenv('SMARTERU_ACCOUNT_KEY') ?? 'No Account Key Provided';
-$userKey = getenv('SMARTERU_USER_KEY') ?? 'No User Key Provided';
+$accountKey = getenv('SMARTERU_ACCOUNT_KEY') ?? null;
+$userKey = getenv('SMARTERU_USER_KEY') ?? null;
+$groupName = $argv[1] ?? null;
+
+function printHelp() {
+    echo <<< END_OF_HELP
+        Prints a CSV Enrollment Report for all active users in the specified group.
+        
+        The script expects the SMARTERU_ACCOUNT_KEY and SMARTERU_USER_KEY environment
+        variables to be set.
+        
+        Usage: php GetEnrollmentReportLiveTest.php <group-name>
+
+        Example: php GetEnrollmentReportLiveTest.php "Widgets Inc."
+    END_OF_HELP;
+}
+// Make sure we have the necessary environment variables to perform the test.
+if (empty($accountKey) || empty($userKey) || empty($groupName)) {
+    printHelp();
+    exit(1);
+}
 
 try {
     // Create the Client for speaking to the API
@@ -34,7 +53,7 @@ try {
     // that are active. Add some optional fields that we care about.
     $results = $client->getLearnerReport(
         (new GetLearnerReportQuery())
-            ->setGroupNames(['SANDBOX - Core Business Solutions'])
+            ->setGroupNames([$groupName])
             ->setUserStatus('Active')
             ->setColumns(['PROGRESS', 'COURSE_DURATION', 'DUE_DATE', ])
     );

--- a/example/GetEnrollmentReportLiveTest.php
+++ b/example/GetEnrollmentReportLiveTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * A live Enrollment Report test.
+ *
+ * @copyright   $year$ Core Business Solutions
+ * @license     MIT
+ * @version     $version$
+ */
+ 
+declare(strict_types=1);
+
+namespace CBS\SmarterU\Tests\Usability;
+
+require_once(__DIR__ . '/../vendor/autoload.php');
+
+use CBS\SmarterU\Client;
+use CBS\SmarterU\DataTypes\User;
+use CBS\SmarterU\DataTypes\Timezone;
+use CBS\SmarterU\Exceptions\SmarterUException;
+use CBS\SmarterU\Queries\GetLearnerReportQuery;
+
+/**
+ * This script contains a live test for Client::createUser. It was used to
+ * intentionally trigger errors and see how the API responds.
+ */
+$accountKey = getenv('SMARTERU_ACCOUNT_KEY') ?? 'No Account Key Provided';
+$userKey = getenv('SMARTERU_USER_KEY') ?? 'No User Key Provided';
+
+try {
+    // Create the Client for speaking to the API
+    $client = new Client($accountKey, $userKey);
+    
+    // Create the user
+    $results = $client->getLearnerReport(
+        (new GetLearnerReportQuery())
+            ->setGroupNames(['SANDBOX - Core Business Solutions'])
+            ->setUserStatus('Active')
+            ->setColumns(['PROGRESS', 'COURSE_DURATION', 'DUE_DATE', ])
+    );
+
+    fputcsv(STDOUT, [
+        'ID',
+        'Given Name',
+        'Surname',
+        'Course Name',
+        'Course Duration',
+        'Is Completed',
+        'Completed Date',
+        'Progress'
+    ]);
+
+    foreach ($results as $learnerReport) {
+        fputcsv(STDOUT, [
+            $learnerReport->getId(),
+            $learnerReport->getGivenName(),
+            $learnerReport->getSurname(),
+            $learnerReport->getCourseName(),
+            $learnerReport->getCourseDuration(),
+            $learnerReport->getProgress() === '100' ? 'Yes' : 'No',
+            $learnerReport->getCompletedDate(),
+            $learnerReport->getProgress()
+        ]);
+    }
+} catch (SmarterUException $error) {
+    var_dump($error);
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -86,6 +86,8 @@ class Client {
      */
     public const SMARTERU_EXCEPTION_MESSAGE = 'SmarterU rejected the request.';
 
+    public const ERROR_GENERIC_REQUEST_FAILURE = 'Failed to make request to SmarterU API. See context for request/response details.';
+
     #endregion constants
 
     #region properties
@@ -1536,7 +1538,7 @@ class Client {
     private function logFailedRequest(string $request, string $response) {
         // Log the request and response.
         $this->logger->error(
-            'Failed to make request to SmarterU API. See context for request/response details.',
+            self::ERROR_GENERIC_REQUEST_FAILURE,
             [
                 'request' => $this->sanitizeRequestXML($request),
                 'response' => $response

--- a/src/Queries/GetLearnerReportQuery.php
+++ b/src/Queries/GetLearnerReportQuery.php
@@ -112,7 +112,7 @@ class GetLearnerReportQuery {
     /**
      * The system-generated identifier for the user's course enrollment.
      */
-    protected string $enrollmentId;
+    protected ?string $enrollmentId = null;
 
     /**
      * The status of groups to return. Acceptable values are "Active",
@@ -284,20 +284,15 @@ class GetLearnerReportQuery {
 
     /**
      * Get the system-generated identifier for the user's course enrollment.
-     *
-     * @return string The system-generated identifier.
      */
-    public function getEnrollmentId(): string {
+    public function getEnrollmentId(): ?string {
         return $this->enrollmentId;
     }
 
     /**
      * Set the system-generated identifier for the user's course enrollment.
-     *
-     * @param string $enrollmentId The system-generated identifier.
-     * @return self
      */
-    public function setEnrollmentId(string $enrollmentId): self {
+    public function setEnrollmentId(?string $enrollmentId): self {
         $this->enrollmentId = $enrollmentId;
         return $this;
     }

--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -1060,7 +1060,12 @@ class XMLGenerator {
         $report->addChild('Page', (string) $query->getPage());
         $report->addChild('PageSize', (string) $query->getPageSize());
         $filters = $report->addChild('Filters');
-        $filters->addChild('EnrollmentID', $query->getEnrollmentId());
+
+        // Don't include EnrollmentId tag if it does not have a value.
+        if (! is_null($query->getEnrollmentId())) {
+            $filters->addChild('EnrollmentID', $query->getEnrollmentId());
+        }
+
         $groups = $filters->addChild('Groups');
         if (!empty($query->getGroupStatus())) {
             $groups->addChild('GroupStatus', $query->getGroupStatus());
@@ -1090,133 +1095,133 @@ class XMLGenerator {
                 $currentTag->addChild('TagValues', $tag->getTagValues());
             }
         }
-        if ($this->includeLearningModulesTag($query)) {
-            $learningModules = $filters->addChild('LearningModules');
-            if (
-                !empty($query->getLearningModuleStatus())
-                || !empty($query->getLearningModuleNames())
-            ) {
-                $learningModule = $learningModules->addChild('LearningModule');
-                if (!empty($query->getLearningModuleStatus())) {
-                    $learningModule->addChild(
-                        'LearningModuleStatus',
-                        $query->getLearningModuleStatus()
-                    );
-                }
-                if (!empty($query->getLearningModuleNames())) {
-                    $names = $learningModule->addChild('LearningModuleNames');
-                    foreach ($query->getLearningModuleNames() as $name) {
-                        $names->addChild('LearningModuleName', $name);
-                    }
-                }
-            }
-            if (!empty($query->getEnrollmentStatuses())) {
-                $enrollmentStatuses = $learningModules->addChild(
-                    'EnrollmentStatuses'
+    
+        $learningModules = $filters->addChild('LearningModules');
+        if (
+            !empty($query->getLearningModuleStatus())
+            || !empty($query->getLearningModuleNames())
+        ) {
+            $learningModule = $learningModules->addChild('LearningModule');
+            if (!empty($query->getLearningModuleStatus())) {
+                $learningModule->addChild(
+                    'LearningModuleStatus',
+                    $query->getLearningModuleStatus()
                 );
-                foreach ($query->getEnrollmentStatuses() as $status) {
-                    $enrollmentStatuses->addChild('EnrollmentStatus', $status);
-                }
             }
-            if (!empty($query->getCompletedDates())) {
-                $completedDates = $learningModules->addChild('CompletedDates');
-                foreach ($query->getCompletedDates() as $date) {
-                    $completedDate = $completedDates->addChild(
-                        'CompletedDate'
-                    );
-                    $completedDate->addChild(
-                        'CompletedDateFrom',
-                        $date->getDateFrom()->format('d-M-y')
-                    );
-                    $completedDate->addChild(
-                        'CompletedDateTo',
-                        $date->getDateTo()->format('d-M-y')
-                    );
-                }
-            }
-            if (!empty($query->getDueDates())) {
-                $dueDates = $learningModules->addChild('DueDates');
-                foreach ($query->getDueDates() as $date) {
-                    $dueDate = $dueDates->addChild('DueDate');
-                    $dueDate->addChild(
-                        'DueDateFrom',
-                        $date->getDateFrom()->format('d-M-y')
-                    );
-                    $dueDate->addChild(
-                        'DueDateTo',
-                        $date->getDateTo()->format('d-M-y')
-                    );
-                }
-            }
-            if (!empty($query->getEnrolledDates())) {
-                $enrolledDates = $learningModules->addChild('EnrolledDates');
-                foreach ($query->getEnrolledDates() as $date) {
-                    $enrolledDate = $enrolledDates->addChild(
-                        'EnrolledDate'
-                    );
-                    $enrolledDate->addChild(
-                        'EnrolledDateFrom',
-                        $date->getDateFrom()->format('d-M-y')
-                    );
-                    $enrolledDate->addChild(
-                        'EnrolledDateTo',
-                        $date->getDateTo()->format('d-M-y')
-                    );
-                }
-            }
-            if (!empty($query->getGracePeriodDates())) {
-                $gracePeriodDates = $learningModules->addChild(
-                    'GracePeriodDates'
-                );
-                foreach ($query->getGracePeriodDates() as $date) {
-                    $gracePeriodDate = $gracePeriodDates->addChild(
-                        'GracePeriodDate'
-                    );
-                    $gracePeriodDate->addChild(
-                        'GracePeriodDateFrom',
-                        $date->getDateFrom()->format('d-M-y')
-                    );
-                    $gracePeriodDate->addChild(
-                        'GracePeriodDateTo',
-                        $date->getDateTo()->format('d-M-y')
-                    );
-                }
-            }
-            if (!empty($query->getLastAccessedDates())) {
-                $lastAccessedDates = $learningModules->addChild(
-                    'LastAccessedDates'
-                );
-                foreach ($query->getLastAccessedDates() as $date) {
-                    $lastAccessedDate = $lastAccessedDates->addChild(
-                        'LastAccessedDate'
-                    );
-                    $lastAccessedDate->addChild(
-                        'LastAccessedDateFrom',
-                        $date->getDateFrom()->format('d-M-y')
-                    );
-                    $lastAccessedDate->addChild(
-                        'LastAccessedDateTo',
-                        $date->getDateTo()->format('d-M-y')
-                    );
-                }
-            }
-            if (!empty($query->getStartedDates())) {
-                $startedDates = $learningModules->addChild('StartedDates');
-                foreach ($query->getStartedDates() as $date) {
-                    $startedDate = $startedDates->addChild(
-                        'StartedDate'
-                    );
-                    $startedDate->addChild(
-                        'StartedDateFrom',
-                        $date->getDateFrom()->format('d-M-y')
-                    );
-                    $startedDate->addChild(
-                        'StartedDateTo',
-                        $date->getDateTo()->format('d-M-y')
-                    );
+            if (!empty($query->getLearningModuleNames())) {
+                $names = $learningModule->addChild('LearningModuleNames');
+                foreach ($query->getLearningModuleNames() as $name) {
+                    $names->addChild('LearningModuleName', $name);
                 }
             }
         }
+        if (!empty($query->getEnrollmentStatuses())) {
+            $enrollmentStatuses = $learningModules->addChild(
+                'EnrollmentStatuses'
+            );
+            foreach ($query->getEnrollmentStatuses() as $status) {
+                $enrollmentStatuses->addChild('EnrollmentStatus', $status);
+            }
+        }
+        if (!empty($query->getCompletedDates())) {
+            $completedDates = $learningModules->addChild('CompletedDates');
+            foreach ($query->getCompletedDates() as $date) {
+                $completedDate = $completedDates->addChild(
+                    'CompletedDate'
+                );
+                $completedDate->addChild(
+                    'CompletedDateFrom',
+                    $date->getDateFrom()->format('d-M-y')
+                );
+                $completedDate->addChild(
+                    'CompletedDateTo',
+                    $date->getDateTo()->format('d-M-y')
+                );
+            }
+        }
+        if (!empty($query->getDueDates())) {
+            $dueDates = $learningModules->addChild('DueDates');
+            foreach ($query->getDueDates() as $date) {
+                $dueDate = $dueDates->addChild('DueDate');
+                $dueDate->addChild(
+                    'DueDateFrom',
+                    $date->getDateFrom()->format('d-M-y')
+                );
+                $dueDate->addChild(
+                    'DueDateTo',
+                    $date->getDateTo()->format('d-M-y')
+                );
+            }
+        }
+        if (!empty($query->getEnrolledDates())) {
+            $enrolledDates = $learningModules->addChild('EnrolledDates');
+            foreach ($query->getEnrolledDates() as $date) {
+                $enrolledDate = $enrolledDates->addChild(
+                    'EnrolledDate'
+                );
+                $enrolledDate->addChild(
+                    'EnrolledDateFrom',
+                    $date->getDateFrom()->format('d-M-y')
+                );
+                $enrolledDate->addChild(
+                    'EnrolledDateTo',
+                    $date->getDateTo()->format('d-M-y')
+                );
+            }
+        }
+        if (!empty($query->getGracePeriodDates())) {
+            $gracePeriodDates = $learningModules->addChild(
+                'GracePeriodDates'
+            );
+            foreach ($query->getGracePeriodDates() as $date) {
+                $gracePeriodDate = $gracePeriodDates->addChild(
+                    'GracePeriodDate'
+                );
+                $gracePeriodDate->addChild(
+                    'GracePeriodDateFrom',
+                    $date->getDateFrom()->format('d-M-y')
+                );
+                $gracePeriodDate->addChild(
+                    'GracePeriodDateTo',
+                    $date->getDateTo()->format('d-M-y')
+                );
+            }
+        }
+        if (!empty($query->getLastAccessedDates())) {
+            $lastAccessedDates = $learningModules->addChild(
+                'LastAccessedDates'
+            );
+            foreach ($query->getLastAccessedDates() as $date) {
+                $lastAccessedDate = $lastAccessedDates->addChild(
+                    'LastAccessedDate'
+                );
+                $lastAccessedDate->addChild(
+                    'LastAccessedDateFrom',
+                    $date->getDateFrom()->format('d-M-y')
+                );
+                $lastAccessedDate->addChild(
+                    'LastAccessedDateTo',
+                    $date->getDateTo()->format('d-M-y')
+                );
+            }
+        }
+        if (!empty($query->getStartedDates())) {
+            $startedDates = $learningModules->addChild('StartedDates');
+            foreach ($query->getStartedDates() as $date) {
+                $startedDate = $startedDates->addChild(
+                    'StartedDate'
+                );
+                $startedDate->addChild(
+                    'StartedDateFrom',
+                    $date->getDateFrom()->format('d-M-y')
+                );
+                $startedDate->addChild(
+                    'StartedDateTo',
+                    $date->getDateTo()->format('d-M-y')
+                );
+            }
+        }
+
         $enrollments = $filters->addChild('Enrollments');
         if (!empty($query->getCreatedDate())) {
             $createdDate = $enrollments->addChild('CreatedDate');
@@ -1259,14 +1264,18 @@ class XMLGenerator {
                 'GetLearnerReport requires either a User Status or User Identifiers.'
             );
         }
-        $columns = $parameters->addChild('Columns');
+
+        
+        $columns = $report->addChild('Columns');
         foreach ($query->getColumns() as $column) {
             $columns->addChild('ColumnName', $column);
         }
-        $customFields = $parameters->addChild('CustomFields');
+        
+        $customFields = $report->addChild('CustomFields');
         foreach ($query->getCustomFields() as $field) {
             $customFields->addChild('FieldName', $field->getName());
         }
+
         return $xml->asXML();
     }
 

--- a/tests/Client/GetLearnerReportClientTest.php
+++ b/tests/Client/GetLearnerReportClientTest.php
@@ -6,7 +6,6 @@
  * @copyright   $year$ Core Business Solutions
  * @license     MIT
  * @version     $version$
- * @since       2022/09/27
  */
 
 declare(strict_types=1);

--- a/tests/Client/GetLearnerReportClientTest.php
+++ b/tests/Client/GetLearnerReportClientTest.php
@@ -6,6 +6,7 @@
  * @copyright   $year$ Core Business Solutions
  * @license     MIT
  * @version     $version$
+ * @since       2022/09/27
  */
 
 declare(strict_types=1);
@@ -169,13 +170,16 @@ class GetLearnerReportClientTest extends TestCase {
         $handlerStack->push($history);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
         $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
-        $logger->expects($this->once())->method('error')->with(
-            $this->identicalTo('Failed to make request to SmarterU API. See context for request/response details.'),
-            $this->identicalTo([
-                'request' => "<?xml version=\"1.0\"?>\n<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>getLearnerReport</Method><Parameters><Report><Page>1</Page><PageSize>50</PageSize><Filters><EnrollmentID>1</EnrollmentID><Groups><GroupStatus>Active</GroupStatus></Groups><Enrollments/><Users><UserStatus>Active</UserStatus></Users></Filters></Report><Columns/><CustomFields/></Parameters></SmarterU>\n",
-                'response' => $body
-            ])
-        );
+        $logger
+            ->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->identicalTo(Client::ERROR_GENERIC_REQUEST_FAILURE),
+                $this->identicalTo([
+                    'request' => "<?xml version=\"1.0\"?>\n<SmarterU><AccountAPI>********</AccountAPI><UserAPI>********</UserAPI><Method>getLearnerReport</Method><Parameters><Report><Page>1</Page><PageSize>50</PageSize><Filters><EnrollmentID>1</EnrollmentID><Groups><GroupStatus>Active</GroupStatus></Groups><LearningModules/><Enrollments/><Users><UserStatus>Active</UserStatus></Users></Filters><Columns/><CustomFields/></Report></Parameters></SmarterU>\n",
+                    'response' => $body
+                ])
+            );
 
         $client
             ->setHttpClient($httpClient)

--- a/tests/XMLGenerator/GetLearnerReportXMLTest.php
+++ b/tests/XMLGenerator/GetLearnerReportXMLTest.php
@@ -120,13 +120,13 @@ class GetLearnerReportXMLTest extends TestCase {
         foreach ($xml->Parameters->children() as $parameter) {
             $parameters[] = $parameter->getName();
         }
-        self::assertCount(3, $parameters);
+        self::assertCount(1, $parameters);
         self::assertContains('Report', $parameters);
         $report = [];
         foreach ($xml->Parameters->Report->children() as $reportTag) {
             $report[] = $reportTag->getName();
         }
-        self::assertCount(3, $report);
+        self::assertCount(5, $report);
         self::assertContains('Page', $report);
         self::assertEquals(
             (int) $xml->Parameters->Report->Page,
@@ -142,7 +142,7 @@ class GetLearnerReportXMLTest extends TestCase {
         foreach ($xml->Parameters->Report->Filters->children() as $tag) {
             $filters[] = $tag->getName();
         }
-        self::assertCount(4, $filters);
+        self::assertCount(5, $filters);
         self::assertContains('EnrollmentID', $filters);
         self::assertEquals(
             $query->getEnrollmentId(),
@@ -172,10 +172,10 @@ class GetLearnerReportXMLTest extends TestCase {
             $query->getUserStatus(),
             $xml->Parameters->Report->Filters->Users->UserStatus
         );
-        self::assertContains('Columns', $parameters);
-        self::assertCount(0, $xml->Parameters->CustomFields->children());
-        self::assertContains('CustomFields', $parameters);
-        self::assertCount(0, $xml->Parameters->CustomFields->children());
+        self::assertArrayHasKey('Columns', (array) $xml->Parameters->Report);
+        self::assertCount(0, (array) $xml->Parameters->CustomFields->children());
+        self::assertArrayHasKey('CustomFields', (array) $xml->Parameters->Report);
+        self::assertCount(0, (array) $xml->Parameters->CustomFields->children());
     }
 
     /**
@@ -284,13 +284,13 @@ class GetLearnerReportXMLTest extends TestCase {
         foreach ($xml->Parameters->children() as $parameter) {
             $parameters[] = $parameter->getName();
         }
-        self::assertCount(3, $parameters);
+        self::assertCount(1, $parameters);
         self::assertContains('Report', $parameters);
         $report = [];
         foreach ($xml->Parameters->Report->children() as $reportTag) {
             $report[] = $reportTag->getName();
         }
-        self::assertCount(3, $report);
+        self::assertCount(5, $report);
         self::assertContains('Page', $report);
         self::assertEquals(
             (int) $xml->Parameters->Report->Page,
@@ -533,13 +533,14 @@ class GetLearnerReportXMLTest extends TestCase {
         foreach ($userEmployeeIds as $id) {
             self::assertContains($id, $ids);
         }
-        self::assertContains('Columns', $parameters);
-        $columnTags = (array) $xml->Parameters->Columns->ColumnName;
+
+        self::assertArrayHasKey('Columns', (array) $xml->Parameters->Report);
+        $columnTags = (array) $xml->Parameters->Report->Columns->ColumnName;
         foreach ($columns as $column) {
             self::assertContains($column, $columnTags);
         }
-        self::assertContains('CustomFields', $parameters);
-        $fields = (array) $xml->Parameters->CustomFields;
+        self::assertArrayHasKey('CustomFields', (array) $xml->Parameters->Report);
+        $fields = (array) $xml->Parameters->Report->CustomFields;
         $fields = $fields['FieldName'];
         foreach ($customFields as $field) {
             self::assertContains($field->getName(), $fields);


### PR DESCRIPTION
If approved this PR makes some changes to the library to make `Client::getLearnerReport()` work as expected, and shores up issues with the unit tests that came up after the fix was made and verified.

**What it doesn't do:**

- Change the language of `Learner Report` to `Enrollment Report`.  I will do that in a follow-up PR once this is  approved and merged.
- Make too many other changes that weren't necessary to make this work. We know the team will benefit from a working query so we can immediately determine "what's possible" via the reporting API.  There are likely code and test coverage improvements to be made but I wanted to take the path of least resistance to provide a proof of concept, so I can get back to doing other things and hand this project off to the team.