### PR TITLE
docs: call out learner report vs. enrollment report

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -989,6 +989,9 @@ class Client {
     /**
      * Make a GetLearnerReport query to the SmarterU API.
      *
+     * Note: SmarterU has begun calling this an Enrollment Report, but the API
+     * method and XML request/response still refer to it as a learner Report.
+     *
      * @param GetLearnerReportQuery $query The query by which to filter the
      *      results of the Learner Report.
      * @return LearnerReport[] A list of all LearnerReports matching the query.

--- a/src/DataTypes/LearnerReport.php
+++ b/src/DataTypes/LearnerReport.php
@@ -20,7 +20,10 @@ use DateTimeInterface;
  * A Learner Report, also known as an Enrollment Report, enables course
  * managers to view the progress of Users who have been assigned to the
  * course. Please refer to the SmarterU documentation for further information:
- * https://support.smarteru.com/v1/docs/enrollment-report
+ * https://support.smarteru.com/v1/docs/enrollment-report.
+ *
+ * Note: SmarterU has begun calling this an Enrollment Report, but the API
+ * method and XML request/response still refer to it as a learner Report.
  */
 class LearnerReport {
     /**


### PR DESCRIPTION
Adds some docblock comments calling out the fact that SmarterU has started calling Learner Report Enrollment Report.