### PR TITLE
fix: give custom fields a default value so getting it doesn't break

### DIFF
--- a/src/DataTypes/LearnerReport.php
+++ b/src/DataTypes/LearnerReport.php
@@ -184,7 +184,7 @@ class LearnerReport {
     /**
      * Any CustomFields specified by the SmarterU API.
      */
-    protected array $customFields;
+    protected array $customFields = [];
 
     /**
      * Get the system-generated identifier for the user's course enrollment.


### PR DESCRIPTION
If approved this fix gives `LearnerReport::$customValues` a default value.

# Why

Previously, if you called `getCustomValues()` and the client had no data with which to populate the field, it would cause an error because the property had no defined value. This allows us to call `getCustomValues()` whether or not the client populated data into it.