### PR TITLE
chore: update phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "psr/log": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "9.5",
+        "phpunit/phpunit": "^9.6",
         "clean/phpdoc-md": "^0.19.1",
         "vimeo/psalm": "^5.26"
     }


### PR DESCRIPTION
This PR if accepted updates the `phpunit` dev dependency to version 9.6.21, the last version to support PHP 8.0