### PR TITLE
fix: use htmlentities to encode some fields in createGroup query [CCP-2437]

### DIFF
--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -547,7 +547,7 @@ class XMLGenerator {
         }
         $groupTag->addChild('Status', $group->getStatus());
         $groupTag->addChild('Description', $group->getDescription());
-        $groupTag->addChild('HomeGroupMessage', $group->getHomeGroupMessage());
+        $groupTag->addChild('HomeGroupMessage', htmlentities($group->getHomeGroupMessage()));
         $notificationEmails = $groupTag->addChild('NotificationEmails');
         foreach ($group->getNotificationEmails() as $email) {
             $notificationEmails->addChild('NotificationEmail', $email);

--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -546,7 +546,7 @@ class XMLGenerator {
             $groupTag->addChild('GroupID', $group->getGroupId());
         }
         $groupTag->addChild('Status', $group->getStatus());
-        $groupTag->addChild('Description', $group->getDescription());
+        $groupTag->addChild('Description', htmlentities($group->getDescription()));
         $groupTag->addChild('HomeGroupMessage', htmlentities($group->getHomeGroupMessage()));
         $notificationEmails = $groupTag->addChild('NotificationEmails');
         foreach ($group->getNotificationEmails() as $email) {


### PR DESCRIPTION
If approved, this PR is a partial solution to CCP-2437. It resolves an issue that occurs when creating a group with ampersands in the name. In order to complete the Jira issue this work needs merge, and we need to roll a revision on this repo and upgrade the version we're pinned to in our application.

To be clear: the code actually worked, but `SimpleXmlElement::addChild()` would flag a warning because of the unescaped `&` character. This warning would surface in the output of our application, and cause the creation operation to appear as if it failed because our JSON response was malformed.