### PR TITLE
fix: logic issue when building learner report query

### DIFF
--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -1247,8 +1247,8 @@ class XMLGenerator {
         if (!empty($query->getUserStatus())) {
             $users->addChild('UserStatus', $query->getUserStatus());
         } else if (
-            !empty($query->getUserEmailAddresses()
-            || !empty($query->getUserEmployeeIds()))
+            !empty($query->getUserEmailAddresses())
+            || !empty($query->getUserEmployeeIds())
         ) {
             $userIdentifier = $users->addChild('UserIdentifier');
             foreach ($query->getUserEmailAddresses() as $email) {


### PR DESCRIPTION
This PR if accepted fixes logic when an array was boolean ored with a boolean then checked for truthiness weirdly that could result in a request for the Learner Report to be incorrectly generated.