### PR TITLE
fix: preserve GroupID in changeGroupMembers so enrolment can't wipe it

### DIFF
--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -919,6 +919,17 @@ class XMLGenerator {
                 'Cannot add or remove users from a Group without a group name or ID.'
             );
         }
+
+        // SmarterU's updateGroup is a full-replace: any field omitted from the
+        // request is cleared on the server. Because a changeGroupMembers
+        // request identifies the group by its Name, omitting the GroupID wipes
+        // it, after which every readGroupById() lookup misses and callers keep
+        // creating duplicate groups. Echo the GroupID back so simply enrolling
+        // a user cannot clear it.
+        if (!empty($group->getGroupId())) {
+            $groupTag->addChild('GroupID', $group->getGroupId());
+        }
+
         $usersTag = $groupTag->addChild('Users');
         foreach ($users as $user) {
             if (!($user instanceof User)) {

--- a/tests/XMLGenerator/ChangeGroupMembersXMLTest.php
+++ b/tests/XMLGenerator/ChangeGroupMembersXMLTest.php
@@ -326,4 +326,83 @@ class ChangeGroupMembersXMLTest extends TestCase {
             $xml->Parameters->Group->SubscriptionVariants->children()
         );
     }
+
+    /**
+     * Test that XMLGenerator::changeGroupMembers() echoes the Group's GroupID
+     * back into the request when the Group has one. changeGroupMembers is an
+     * updateGroup request, and SmarterU's updateGroup is a full-replace: any
+     * field omitted from the request is cleared on the server. Omitting the
+     * GroupID therefore wipes it, orphaning the group from every
+     * readGroupById() lookup. The GroupID must survive a membership change.
+     */
+    public function testChangeGroupMembersPreservesGroupId(): void {
+        $accountApi = 'account';
+        $userApi = 'user';
+        $user = (new User())
+            ->setEmail('test@test.com')
+            ->setHomeGroup('My Group');
+        $group = (new Group())
+            ->setName('My Group')
+            ->setGroupId('my-group-id');
+        $action = 'Add';
+        $xmlGenerator = new XMLGenerator();
+        $xml = $xmlGenerator->changeGroupMembers(
+            $accountApi,
+            $userApi,
+            [$user],
+            $group,
+            $action
+        );
+        self::assertIsString($xml);
+        $xml = simplexml_load_string($xml);
+
+        // The group is still identified by its Name, not its GroupID.
+        self::assertEquals(
+            $group->getName(),
+            $xml->Parameters->Group->Identifier->Name
+        );
+
+        // The GroupID is present as a sibling of the Identifier so the
+        // full-replace re-asserts it rather than clearing it.
+        $groupTags = [];
+        foreach ($xml->Parameters->Group->children() as $tag) {
+            $groupTags[] = $tag->getName();
+        }
+        self::assertContains('GroupID', $groupTags);
+        self::assertEquals(
+            $group->getGroupId(),
+            $xml->Parameters->Group->GroupID
+        );
+    }
+
+    /**
+     * Test that XMLGenerator::changeGroupMembers() omits the GroupID tag when
+     * the Group has no GroupID, so a group identified only by name is
+     * unaffected.
+     */
+    public function testChangeGroupMembersOmitsGroupIdWhenAbsent(): void {
+        $accountApi = 'account';
+        $userApi = 'user';
+        $user = (new User())
+            ->setEmail('test@test.com')
+            ->setHomeGroup('My Group');
+        $group = (new Group())
+            ->setName('My Group');
+        $xmlGenerator = new XMLGenerator();
+        $xml = $xmlGenerator->changeGroupMembers(
+            $accountApi,
+            $userApi,
+            [$user],
+            $group,
+            'Add'
+        );
+        self::assertIsString($xml);
+        $xml = simplexml_load_string($xml);
+
+        $groupTags = [];
+        foreach ($xml->Parameters->Group->children() as $tag) {
+            $groupTags[] = $tag->getName();
+        }
+        self::assertNotContains('GroupID', $groupTags);
+    }
 }


### PR DESCRIPTION
## Problem

`changeGroupMembers()` (used by `addUsersToGroup()` / `removeUsersFromGroup()`) builds a request with `Method=updateGroup`. SmarterU's `updateGroup` is a **full-replace**: any field omitted from the request is cleared on the server.

The request identifies the group by its **Name** and **never emits a `<GroupID>`**. So every time a user is added to or removed from a group, SmarterU clears that group's GroupID.

### Downstream impact (observed in production)

Once a group's GroupID is wiped:

- `readGroupById(<slug>)` misses even though the group still exists by name.
- Callers that resolve a group by ID conclude it doesn't exist and try to **create** it → SmarterU rejects with `CG:22` (name already in use) → they fall back to creating **duplicate, disambiguated** groups (`"Name (slug)"`).
- Because member enrolment runs on **every** SSO/provisioning, the GroupID is re-wiped on each login, so a manually-repaired GroupID does not survive and the group can never stabilise.

This surfaced as users being unable to SSO into the Learning Center, with `CG:22` on group creation and `UG:22` ("User is not a part of the provided account") on enrolment.

## Fix

Echo the group's `GroupID` back into the `changeGroupMembers` payload when the group has one, so a membership change **re-asserts** the GroupID instead of clearing it. The group continues to be identified by its `Name`; groups that have no GroupID are unaffected (no `<GroupID>` tag is emitted).

```php
if (!empty($group->getGroupId())) {
    $groupTag->addChild('GroupID', $group->getGroupId());
}
```

As a bonus this is self-healing: the first membership change after a group's correct GroupID is known re-asserts it rather than wiping it.

## Tests

- `testChangeGroupMembersPreservesGroupId` — group with a name **and** a GroupID emits the `<GroupID>` and still identifies by `Name`.
- `testChangeGroupMembersOmitsGroupIdWhenAbsent` — group with only a name emits **no** `<GroupID>` (existing behaviour preserved).

Full suite passes locally: **1320 tests, 3542 assertions**. No new `phpcs` violations on the changed files.

> Note: `psalm` and one pre-existing `phpcs` violation (`src/XMLGenerator.php:354`, unrelated code) were already failing on `main` in my local PHP 8.4 environment; both are pre-existing and out of scope for this change.

## Open question for reviewers

`changeGroupMembers` also omits `Status`, `Description`, and `HomeGroupMessage`. If SmarterU full-replaces those too, enrolment may be blanking them as well. This PR intentionally fixes only the confirmed, outage-causing field (GroupID); worth a follow-up to confirm/preserve the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group member updates now retain the group identifier when available, improving request accuracy.
  * Updates without a group identifier continue to work as expected.

* **Tests**
  * Added coverage for group updates with and without identifiers.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->