### PR TITLE
fix: Escape ampersands in changeGroupMembers group name

### DIFF
--- a/src/XMLGenerator.php
+++ b/src/XMLGenerator.php
@@ -911,7 +911,7 @@ class XMLGenerator {
         $groupTag = $parameters->addChild('Group');
         $identifier = $groupTag->addChild('Identifier');
         if (!empty($group->getName())) {
-            $identifier->addChild('Name', $group->getName());
+            $identifier->addChild('Name', $this->escapeValue($group->getName()));
         } else if (!empty($group->getGroupId())) {
             $identifier->addChild('GroupID', $group->getGroupId());
         } else {


### PR DESCRIPTION
## Describe Your Changes

If approved, this PR fixes Learning Center lockouts for realms whose company name contains an ampersand by routing the group name in `changeGroupMembers()` through the existing `escapeValue()` helper, as `createGroup()` already does.

`SimpleXMLElement::addChild()` escapes `<` and `>` but not `&`. A group name such as `J Terry & Associates Inc.` therefore raised an `unterminated entity reference` warning and the value was dropped in its entirety, so the request went out as `<Identifier><Name/></Identifier>`. SmarterU rejected the `updateGroup` call with `UG:01 The name provided is not valid`.

The user impact was not limited to a single call: CCP enrols the user in their home group on every SSO login, so once an affected user existed in SmarterU, every subsequent Learning Center login failed. Only the very first login (which goes through `createUser`, already escaped) succeeded.

With this change the name round-trips correctly as `J Terry &amp; Associates Inc.`, the warning is gone, and the `GroupID` preservation added in #58 is unaffected. The existing suite passes unchanged (1320 tests, 3542 assertions).

Note that `changeGroupMembers` was the last unescaped group-name call site; escaping elsewhere in `XMLGenerator` is still inconsistent (a mix of `escapeValue()`, `htmlentities()`, and nothing at all), and `htmlentities()` emits HTML-named entities that are not valid in XML for non-ASCII names. Those are left alone here to keep this a minimal hotfix, and are being tracked separately on CCP-4209.

## Related Issues

This PR solves CCP-4220 (customer report) and is the hotfix portion of CCP-4209.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed XML generation for group names containing ampersands, ensuring they are properly escaped and processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->